### PR TITLE
限定公開記事(is_secret)の閲覧ゲート・漏洩経路対策

### DIFF
--- a/cms-cache-purger/src/blog.ts
+++ b/cms-cache-purger/src/blog.ts
@@ -1,4 +1,4 @@
-import { WebhookPayload } from 'api-types'
+import { Content, WebhookPayload } from 'api-types'
 import { deleteCacheByPrefix, deleteCache } from './kv'
 import { Env } from './index'
 import { generateContentKey, generateInfoKey, generateStaticDataKey, generateTagsKey } from 'cms-cache-key-gen'
@@ -44,18 +44,20 @@ export default class Blog {
   }
 
   private async editContent(bodyJSON: WebhookPayload) {
-    if (this.isDraftToPublish(bodyJSON.contents.old, bodyJSON.contents.new)) {
-      // 下書きから公開に変更された場合
-      // contentsのキャッシュを削除する
+    // 編集時は対象IDの単体キャッシュは常に削除する
+    console.log('start deleteContentCache')
+    console.log('id: ' + bodyJSON.id)
+    const cacheKey = generateContentKey(bodyJSON.id)
+    await deleteCache(this.env, cacheKey)
+
+    // 下書き→公開、または限定公開フラグ(is_secret)の変更時は
+    // 記事の一覧表示有無が変わるため一覧キャッシュ(contents_*)も削除する
+    if (
+      this.isDraftToPublish(bodyJSON.contents.old, bodyJSON.contents.new) ||
+      this.isSecretChanged(bodyJSON.contents.old, bodyJSON.contents.new)
+    ) {
       console.log('start deleteContentsCache')
       await deleteCacheByPrefix(this.env, this.prefix)
-    } else {
-      // ブログのメインコンテンツに編集があった場合
-      // 対象のIDのコンテンツのキャッシュを削除する
-      console.log('start deleteContentCache')
-      console.log('id: ' + bodyJSON.id)
-      const cacheKey = generateContentKey(bodyJSON.id)
-      await deleteCache(this.env, cacheKey)
     }
   }
 
@@ -72,5 +74,16 @@ export default class Blog {
 
   private isDraftToPublish(oldContent: any, newContent: any): boolean {
     return oldContent.status.includes('DRAFT') && newContent.status.includes('PUBLISH')
+  }
+
+  // 限定公開フラグ(is_secret)が変更されたか（公開値ベースで比較）
+  // 未設定は false 扱い。old が無い場合は変更なしとみなす
+  private isSecretChanged(oldContent: Content | null, newContent: Content): boolean {
+    if (oldContent === null) {
+      return false
+    }
+    const oldSecret = oldContent.publishValue?.is_secret ?? false
+    const newSecret = newContent.publishValue?.is_secret ?? false
+    return oldSecret !== newSecret
   }
 }

--- a/cms-data-fetcher/src/index.ts
+++ b/cms-data-fetcher/src/index.ts
@@ -21,6 +21,7 @@ import {
   getTags,
   getAtelier,
   getAteliers,
+  getSecretMeta,
 } from './micro_cms'
 import { parse } from './parse'
 import { WorkerEntrypoint } from 'cloudflare:workers'
@@ -61,6 +62,13 @@ export default class CMSDataFetcher extends WorkerEntrypoint<Env> {
       // 通常の記事一覧での取得
       const contents = await this.fetchContents(offset, limit)
       return Response.json(contents)
+    } else if (pathname.includes('/cms/get_secret_meta')) {
+      // 限定公開記事のコード照合用メタ（is_secret / secret_code）を取得
+      if (articleID === null) {
+        return new Response('articleID is empty', { status: 400 })
+      }
+      const meta = await this.fetchSecretMeta(articleID)
+      return Response.json(meta)
     } else if (pathname.includes('/cms/get_content')) {
       // 単独の記事を取得
       if (articleID === null) {
@@ -151,6 +159,12 @@ export default class CMSDataFetcher extends WorkerEntrypoint<Env> {
     content.annotations = parsed.annotations
     // Cheerioオブジェクトに含まれる関数を削ぎ落とすためにJSON経由でシリアライズ
     return JSON.parse(JSON.stringify(content))
+  }
+
+  // 限定公開記事のコード照合用メタを取得する。secret_code を含むためクライアントには渡さない
+  async fetchSecretMeta(articleID: string): Promise<{ is_secret: boolean; secret_code: string | null }> {
+    const apiKey = this.env.CMS_API_KEY
+    return await getSecretMeta(apiKey, articleID)
   }
 
   async fetchTags(): Promise<categoryAPIResult[]> {

--- a/cms-data-fetcher/src/micro_cms.ts
+++ b/cms-data-fetcher/src/micro_cms.ts
@@ -72,6 +72,48 @@ export async function getContent(apiKey: string, articleID: string, draftKey?: s
   return parseContentsAPIResult(response.contents[0])
 }
 
+// 限定公開記事のコード照合用に is_secret と secret_code のみを取得する（本文は取得しない）
+// secret_code を含むため、この結果はクライアントへ渡さずサーバ側の照合でのみ使用する
+export async function getSecretMeta(
+  apiKey: string,
+  articleID: string
+): Promise<{ is_secret: boolean; secret_code: string | null }> {
+  if (apiKey === undefined) {
+    throw new Error('API_KEY is undefined')
+  }
+
+  const client = createClient({
+    serviceDomain: 'maretol-blog',
+    apiKey: apiKey,
+  })
+
+  const response = await client
+    .getList<{ id: string; is_secret?: boolean; secret_code?: string }>({
+      endpoint: 'contents',
+      queries: { ids: articleID, fields: 'id,is_secret,secret_code' },
+    })
+    .then((res) => {
+      return res
+    })
+    .catch((err) => {
+      console.log(err)
+    })
+
+  if (response === undefined) {
+    throw new Error('api access error')
+  }
+
+  const content = response.contents[0]
+  if (content === undefined) {
+    return { is_secret: false, secret_code: null }
+  }
+
+  return {
+    is_secret: content.is_secret ?? false,
+    secret_code: content.secret_code ?? null,
+  }
+}
+
 // タグ一覧を取得するAPIアクセス
 export async function getTags(apiKey: string) {
   if (apiKey === undefined) {

--- a/packages/api-types/src/cms_webhook_types.ts
+++ b/packages/api-types/src/cms_webhook_types.ts
@@ -31,4 +31,5 @@ export type ContentValue = {
   first_page: number // comicのときの1ページ目のファイル番号
   filename: string // comicのときの1ページ目を取り出すときに利用する値
   format: string[] // comicのときのファイル形式
+  is_secret?: boolean // blogのときの限定公開フラグ。trueの場合は一覧非表示・SNS自動投稿の対象外とする
 }

--- a/packages/cms-cache-key-gen/src/generator.ts
+++ b/packages/cms-cache-key-gen/src/generator.ts
@@ -6,6 +6,10 @@ export function generateContentKey(articleID: string) {
   return `content_${articleID}`
 }
 
+export function generateSecretMetaKey(articleID: string) {
+  return `secret_meta_${articleID}`
+}
+
 export function generateContentsWithTagsKey(tagIDs: string[], offset: string, limit: string) {
   tagIDs = tagIDs.sort()
   return `contents_with_tags_${tagIDs.join('_')}_${offset}_${limit}`

--- a/pages/app/blog/[article_id]/actions.ts
+++ b/pages/app/blog/[article_id]/actions.ts
@@ -1,0 +1,34 @@
+'use server'
+
+import { getSecretMeta } from '@/lib/api/workers'
+import { constantTimeEqual, setArticleUnlocked } from '@/lib/secret_unlock'
+import { revalidatePath } from 'next/cache'
+
+export type UnlockState = { ok: boolean; error?: string }
+
+// 限定公開記事の閲覧コードを照合し、一致したら解錠 Cookie を発行する
+// articleID は呼び出し側で bind して渡す（useActionState のシグネチャに合わせる）
+export async function unlockSecretArticle(
+  articleID: string,
+  _prevState: UnlockState,
+  formData: FormData,
+): Promise<UnlockState> {
+  const input = (formData.get('secret_code') ?? '').toString()
+  if (input === '') {
+    return { ok: false, error: 'コードを入力してください' }
+  }
+
+  const meta = await getSecretMeta(articleID)
+  if (!meta.is_secret || meta.secret_code == null || meta.secret_code === '') {
+    // 限定公開でない、またはコード未設定（誤設定）の場合は解錠しない
+    return { ok: false, error: '認証できませんでした' }
+  }
+
+  if (!constantTimeEqual(input, meta.secret_code)) {
+    return { ok: false, error: 'コードが違います' }
+  }
+
+  await setArticleUnlocked(articleID)
+  revalidatePath(`/blog/${articleID}`)
+  return { ok: true }
+}

--- a/pages/app/blog/[article_id]/actions.ts
+++ b/pages/app/blog/[article_id]/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { getSecretMeta } from '@/lib/api/workers'
-import { constantTimeEqual, setArticleUnlocked } from '@/lib/secret_unlock'
+import { secureEqual, setArticleUnlocked } from '@/lib/secret_unlock'
 import { revalidatePath } from 'next/cache'
 
 export type UnlockState = { ok: boolean; error?: string }
@@ -24,7 +24,7 @@ export async function unlockSecretArticle(
     return { ok: false, error: '認証できませんでした' }
   }
 
-  if (!constantTimeEqual(input, meta.secret_code)) {
+  if (!(await secureEqual(input, meta.secret_code))) {
     return { ok: false, error: 'コードが違います' }
   }
 

--- a/pages/app/blog/[article_id]/article.tsx
+++ b/pages/app/blog/[article_id]/article.tsx
@@ -1,6 +1,8 @@
 import { FullArticle } from '@/components/large/article'
 import { getCMSContent } from '@/lib/api/workers'
+import { isArticleUnlocked } from '@/lib/secret_unlock'
 import { contentsAPIResult } from 'api-types'
+import SecretGate from './secret_gate'
 
 export default async function BlogPageArticle({
   articleID,
@@ -12,6 +14,16 @@ export default async function BlogPageArticle({
   url: string
 }) {
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
+
+  // 限定公開記事はコード解錠まで本文を出さない（draftKey でのプレビューはバイパス）
+  if (content.is_secret && draftKey === undefined && !(await isArticleUnlocked(articleID))) {
+    return (
+      <div>
+        <SecretGate articleID={content.id} title={content.title} />
+      </div>
+    )
+  }
+
   return (
     <div>
       <FullArticle

--- a/pages/app/blog/[article_id]/image/[src]/page.tsx
+++ b/pages/app/blog/[article_id]/image/[src]/page.tsx
@@ -20,18 +20,25 @@ export async function generateMetadata(props: {
   const draftKey = searchParams['draftKey']
 
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
+
+  // 限定公開記事（未解錠）は本文をメタに出さず、検索インデックスも避ける（page.tsx と同様）
+  const isSecretLocked = content.is_secret === true && draftKey === undefined
+
   const ogpImage = content.ogp_image
-  const ogpURL = getOGPImageURL(ogpImage || getDefaultOGPImageURL())
-  const description = content.parsed_content
-    .slice(0, 5)
-    .map((c) => c.text)
-    .join(' ')
-  const twitterCard = ogpImage === null || ogpImage === undefined ? 'summary' : 'summary_large_image'
+  const ogpURL = getOGPImageURL(isSecretLocked || !ogpImage ? getDefaultOGPImageURL() : ogpImage)
+  const description = isSecretLocked
+    ? '限定公開記事です'
+    : content.parsed_content
+        .slice(0, 5)
+        .map((c) => c.text)
+        .join(' ')
+  const twitterCard = isSecretLocked || ogpImage === null || ogpImage === undefined ? 'summary' : 'summary_large_image'
 
   return {
     ...metadata,
     title: `IMAGE: ${content.title} | Maretol Base`,
     description: content.title,
+    robots: isSecretLocked ? { index: false, follow: false } : undefined,
     twitter: {
       ...metadata.twitter,
       card: twitterCard,

--- a/pages/app/blog/[article_id]/page.tsx
+++ b/pages/app/blog/[article_id]/page.tsx
@@ -19,19 +19,27 @@ export async function generateMetadata(props: {
   const draftKey = parseDraftKey(searchParams)
 
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
+
+  // 限定公開記事（未解錠）は本文をメタに出さず、検索インデックスも避ける
+  const isSecretLocked = content.is_secret === true && draftKey === undefined
+
   const ogpImage = content.ogp_image
-  const ogpSrc = ogpImage === null || ogpImage === undefined ? getDefaultOGPImageURL() : ogpImage
+  const ogpSrc =
+    isSecretLocked || ogpImage === null || ogpImage === undefined ? getDefaultOGPImageURL() : ogpImage
   const ogpURL = getOGPImageURL(ogpSrc)
-  const description = content.parsed_content
-    .slice(0, 5)
-    .map((c) => c.text)
-    .join(' ')
-  const twitterCard = ogpImage === null || ogpImage === undefined ? 'summary' : 'summary_large_image'
+  const description = isSecretLocked
+    ? '限定公開記事です'
+    : content.parsed_content
+        .slice(0, 5)
+        .map((c) => c.text)
+        .join(' ')
+  const twitterCard = isSecretLocked || ogpImage === null || ogpImage === undefined ? 'summary' : 'summary_large_image'
 
   return {
     ...metadata,
     title: content.title + ' | Maretol Base',
     description: content.title,
+    robots: isSecretLocked ? { index: false, follow: false } : undefined,
     twitter: {
       ...metadata.twitter,
       card: twitterCard,

--- a/pages/app/blog/[article_id]/secret_gate.tsx
+++ b/pages/app/blog/[article_id]/secret_gate.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { EyeIcon, EyeOffIcon, LockIcon } from 'lucide-react'
+import { useActionState, useState, type CSSProperties } from 'react'
+import { unlockSecretArticle, type UnlockState } from './actions'
+import { Input } from '@/components/ui/input'
+import Form from 'next/form'
+
+const initialState: UnlockState = { ok: false }
+
+export default function SecretGate({ articleID, title }: { articleID: string; title: string }) {
+  // articleID を bind して useActionState のシグネチャ (state, formData) に合わせる
+  const action = unlockSecretArticle.bind(null, articleID)
+  const [state, formAction, pending] = useActionState(action, initialState)
+  // 入力中のコードのマスク表示の切り替え（デフォルトは非マスク = 表示）
+  const [masked, setMasked] = useState(false)
+
+  return (
+    <div className="flex flex-col items-center gap-6 rounded-md bg-gray-100 px-6 py-12">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <LockIcon className="h-8 w-8 text-gray-500" />
+        <h1 className="text-xl font-bold font-suse">{title}</h1>
+        <p className="text-sm text-gray-600">この記事は限定公開です。閲覧コードを入力してください。</p>
+      </div>
+      <Form action={formAction} className="flex w-full max-w-sm flex-col items-center gap-3">
+        {/*
+          パスワードマネージャに保存させないため type="password" を使わない。
+          （password 欄では autocomplete="off" がブラウザに無視され保存提案が出るため）
+          デフォルトは非マスク表示。マスクボタンで任意にマスク表示へ切り替えられる
+          （マスクは -webkit-text-security 利用のため Chromium/Safari のみ。Firefox では効かない）
+        */}
+        <div className="relative w-full">
+          <Input
+            name="secret_code"
+            type="text"
+            autoComplete="off"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            data-1p-ignore
+            data-lpignore="true"
+            data-bwignore
+            aria-label="閲覧コード"
+            style={{ WebkitTextSecurity: masked ? 'disc' : 'none' } as CSSProperties}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 pr-10 focus:border-gray-500 focus:outline-none"
+            placeholder="閲覧コード"
+          />
+          <button
+            type="button"
+            onClick={() => setMasked((m) => !m)}
+            aria-label={masked ? 'コードを表示' : 'コードをマスク'}
+            aria-pressed={masked}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+          >
+            {masked ? <EyeIcon className="h-5 w-5" /> : <EyeOffIcon className="h-5 w-5" />}
+          </button>
+        </div>
+        {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+        <Button type="submit" disabled={pending} className="w-full gap-1 font-suse">
+          <LockIcon className="h-4 w-4" />
+          {pending ? '確認中...' : '解錠する'}
+        </Button>
+      </Form>
+    </div>
+  )
+}

--- a/pages/components/middle/article_dom/blogcard.tsx
+++ b/pages/components/middle/article_dom/blogcard.tsx
@@ -2,7 +2,7 @@ import ClientImage2 from '@/components/small/client_image2'
 import { Button } from '@/components/ui/button'
 import { getCMSContent } from '@/lib/api/workers'
 import { convertJST } from '@/lib/time'
-import { NotebookText } from 'lucide-react'
+import { LockIcon, NotebookText } from 'lucide-react'
 import Link from 'next/link'
 
 export default async function BlogCard({ link }: { link: string }) {
@@ -10,6 +10,29 @@ export default async function BlogCard({ link }: { link: string }) {
   const linkPath = linkURL.pathname
   const articleID = linkPath.split('/')[2]
   const linkArticle = await getCMSContent(articleID)
+
+  // 限定公開記事は常にマスク表示する
+  // （タイトルはゲート/metadataで公開済みの線引きに合わせて表示。サムネ・公開日は伏せる）
+  if (linkArticle.is_secret) {
+    return (
+      <div className="max-w-2xl">
+        <div className="bg-gray-300 h-full w-full px-4 py-2 rounded-md">
+          <div className="flex items-center gap-2">
+            <LockIcon className="w-6 h-6 shrink-0" />
+            <div className="w-full flex flex-col self-end">
+              <p className="text-md font-semibold text-wrap line-clamp-2">{linkArticle.title}</p>
+              <p className="text-gray-500 text-xs">限定公開・コード入力で閲覧</p>
+            </div>
+            <div>
+              <Button className="h-8" asChild>
+                <Link href={linkPath}>Read this</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   const articleTitle = linkArticle.title
   const articlePublishedAt = linkArticle.publishedAt

--- a/pages/components/ui/input.tsx
+++ b/pages/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/pages/env.d.ts
+++ b/pages/env.d.ts
@@ -9,6 +9,7 @@ interface CloudflareEnv {
   IMAGE_CACHE: KVNamespace
   CMS_FETCHER_API_KEY: string
   OGP_FETCHER_API_KEY: string
+  SECRET_ARTICLE_COOKIE_KEY: string // 限定公開記事の解錠Cookie署名用シークレット
   HOST: string
   CMS_RPC: Service<CMSDataFetcher>
   OGP_RPC: Service<OGPDataFetcher>

--- a/pages/env.d.ts
+++ b/pages/env.d.ts
@@ -9,7 +9,7 @@ interface CloudflareEnv {
   IMAGE_CACHE: KVNamespace
   CMS_FETCHER_API_KEY: string
   OGP_FETCHER_API_KEY: string
-  SECRET_ARTICLE_COOKIE_KEY: string // 限定公開記事の解錠Cookie署名用シークレット
+  SECRET_ARTICLE_COOKIE_KEY: SecretsStoreSecret
   HOST: string
   CMS_RPC: Service<CMSDataFetcher>
   OGP_RPC: Service<OGPDataFetcher>

--- a/pages/lib/api/workers.ts
+++ b/pages/lib/api/workers.ts
@@ -13,6 +13,7 @@ import {
   generateBandeDessineeContentKey,
   generateBandeDessineeKey,
   generateContentKey,
+  generateSecretMetaKey,
   generateContentsKey,
   generateContentsWithTagsKey,
   generateStaticDataKey,
@@ -32,6 +33,7 @@ const CacheTTL = {
   ogpData: 3 * DAY, // OGPデータの保持
   contents: 15 * DAY, // トップページなどのブログコンテンツリスト
   content: 10 * DAY, // 特定のブログコンテンツ
+  secretMeta: 0, // 限定公開記事のコード照合メタ。secret_codeを含むため常にskipCache（保持しない）
   contentsWithTags: 10 * DAY, // タグ指定のブログコンテンツリスト
   tags: 30 * DAY, // タグリスト
   info: 30 * DAY, // 特定ページ（静的ページ）の情報。変更が少ないためキャッシュ長め
@@ -113,6 +115,7 @@ async function createLocalFetcher<TResult>(
 const getOGPData = cache(getOGPDataOrigin)
 const getCMSContents = cache(getCMSContentsOrigin)
 const getCMSContent = cache(getCMSContentOrigin)
+const getSecretMeta = cache(getSecretMetaOrigin)
 const getCMSContentsWithTags = cache(getCMSContentsWithTagsOrigin)
 const getTags = cache(getTagsOrigin)
 const getInfo = cache(getInfoOrigin)
@@ -218,6 +221,27 @@ async function getCMSContentOrigin(articleID: string, draftKey?: string) {
       : () => env.CMS_RPC.fetchContent(articleID, draftKey || null),
     defaultResult,
     skipCache: !!draftKey, // draftKeyがある場合はキャッシュをスキップ
+    // 限定公開記事は本文を KV に残さないようキャッシュ保存しない
+    shouldCache: (res) => res?.is_secret !== true,
+  })
+}
+
+// 限定公開記事のコード照合用メタ（is_secret / secret_code）の取得
+// secret_code を含むため skipCache で常にキャッシュせず、サーバ側の照合処理でのみ利用する
+async function getSecretMetaOrigin(articleID: string) {
+  const { env } = await getCloudflareContext({ async: true })
+  const isLocal = getLocalEnv() === 'local'
+  const defaultResult: { is_secret: boolean; secret_code: string | null } = { is_secret: false, secret_code: null }
+
+  return createCachedAPIFunction<{ is_secret: boolean; secret_code: string | null }>({
+    cacheKey: generateSecretMetaKey(articleID),
+    cacheTTL: CacheTTL.secretMeta,
+    cacheStore: env.CMS_CACHE,
+    fetcher: isLocal
+      ? () => createLocalFetcher('/api/cms/get_secret_meta', { article_id: articleID }, defaultResult)
+      : () => env.CMS_RPC.fetchSecretMeta(articleID),
+    defaultResult,
+    skipCache: true, // secret_code を KV に保存しないため常にキャッシュをスキップする
   })
 }
 
@@ -387,6 +411,7 @@ export {
   getOGPData,
   getCMSContents,
   getCMSContent,
+  getSecretMeta,
   getCMSContentsWithTags,
   getTags,
   getInfo,

--- a/pages/lib/env.ts
+++ b/pages/lib/env.ts
@@ -33,11 +33,15 @@ function isKVCacheEnabled() {
 }
 
 async function getSecretArticleCookieKey(env: CloudflareEnv) {
-  const key = await env.SECRET_ARTICLE_COOKIE_KEY.get()
-  if (!key && getNodeEnv() !== 'production') {
-    return 'test_dev_key'
+  try {
+    const key = await env.SECRET_ARTICLE_COOKIE_KEY.get()
+    return key
+  } catch (e) {
+    if (getNodeEnv() !== 'production') {
+      return 'test_dev_key'
+    }
+    throw new Error('SECRET_ARTICLE_COOKIE_KEY is not set')
   }
-  return key
 }
 
 export { getHostname, getLocalEnv, getNodeEnv, getEnv, isKVCacheEnabled, getSecretArticleCookieKey }

--- a/pages/lib/env.ts
+++ b/pages/lib/env.ts
@@ -32,16 +32,22 @@ function isKVCacheEnabled() {
   return KV_CACHE_ENABLED
 }
 
-async function getSecretArticleCookieKey(env: CloudflareEnv) {
+async function getSecretArticleCookieKey(env: CloudflareEnv): Promise<string> {
   try {
     const key = await env.SECRET_ARTICLE_COOKIE_KEY.get()
-    return key
-  } catch (e) {
-    if (getNodeEnv() !== 'production') {
-      return 'test_dev_key'
+    if (key) {
+      return key
     }
-    throw new Error('SECRET_ARTICLE_COOKIE_KEY is not set')
+    // get() が null/空を返すケースも下のフォールバック判定に流す（例外時と挙動を揃える）
+  } catch (e) {
+    // binding 未設定などで get() が例外を投げるケースも同様に扱う
   }
+  // 鍵が未設定/空のとき: ローカル環境のみ既定値を許容し、それ以外はエラーにする。
+  // 推測可能な固定鍵で解錠Cookieを偽造されるのを防ぐため、preview等でも未設定はエラー。
+  if (getLocalEnv() === 'local') {
+    return 'test_dev_key'
+  }
+  throw new Error('SECRET_ARTICLE_COOKIE_KEY is not set')
 }
 
 export { getHostname, getLocalEnv, getNodeEnv, getEnv, isKVCacheEnabled, getSecretArticleCookieKey }

--- a/pages/lib/env.ts
+++ b/pages/lib/env.ts
@@ -32,4 +32,12 @@ function isKVCacheEnabled() {
   return KV_CACHE_ENABLED
 }
 
-export { getHostname, getLocalEnv, getNodeEnv, getEnv, isKVCacheEnabled }
+function getSecretArticleCookieKey() {
+  const key = process.env.SECRET_ARTICLE_COOKIE_KEY
+  if (!key && getNodeEnv() !== 'production') {
+    return 'test_dev_key'
+  }
+  return key
+}
+
+export { getHostname, getLocalEnv, getNodeEnv, getEnv, isKVCacheEnabled, getSecretArticleCookieKey }

--- a/pages/lib/env.ts
+++ b/pages/lib/env.ts
@@ -32,8 +32,8 @@ function isKVCacheEnabled() {
   return KV_CACHE_ENABLED
 }
 
-function getSecretArticleCookieKey() {
-  const key = process.env.SECRET_ARTICLE_COOKIE_KEY
+async function getSecretArticleCookieKey(env: CloudflareEnv) {
+  const key = await env.SECRET_ARTICLE_COOKIE_KEY.get()
   if (!key && getNodeEnv() !== 'production') {
     return 'test_dev_key'
   }

--- a/pages/lib/secret_unlock.ts
+++ b/pages/lib/secret_unlock.ts
@@ -1,0 +1,75 @@
+// 限定公開記事の「解錠状態」を署名付き Cookie で保持するためのサーバ専用ユーティリティ
+//   - Cookie 値は HMAC-SHA256(articleID, SECRET_ARTICLE_COOKIE_KEY) の hex
+//   - 解錠時に発行し、以降の閲覧は Cookie 検証のみで本文を表示する（コード再入力不要）
+//   - secret_code そのものは Cookie に保存しない（解錠の瞬間だけ照合に使う）
+
+import { cookies } from 'next/headers'
+import { getSecretArticleCookieKey } from './env'
+
+const COOKIE_PREFIX = 'secret_unlock_'
+const MAX_AGE = 60 * 60 * 24 * 30 // 30日
+
+function cookieName(articleID: string) {
+  return `${COOKIE_PREFIX}${articleID}`
+}
+
+async function getSigningKey(): Promise<string> {
+  const key = getSecretArticleCookieKey()
+  if (!key) {
+    throw new Error('SECRET_ARTICLE_COOKIE_KEY is not set')
+  }
+  return key
+}
+
+function bufferToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+async function sign(articleID: string): Promise<string> {
+  const keyData = new TextEncoder().encode(await getSigningKey())
+  const cryptoKey = await crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(articleID))
+  return bufferToHex(signature)
+}
+
+// 長さ・内容のタイミング差を抑えた文字列比較
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}
+
+// 対象記事が解錠済み（有効な署名 Cookie を持つ）かどうか
+export async function isArticleUnlocked(articleID: string): Promise<boolean> {
+  const store = await cookies()
+  const cookie = store.get(cookieName(articleID))
+  if (!cookie) {
+    return false
+  }
+  try {
+    const expected = await sign(articleID)
+    return constantTimeEqual(cookie.value, expected)
+  } catch {
+    return false
+  }
+}
+
+// 対象記事を解錠済みにする署名 Cookie を発行する（Server Action / Route Handler からのみ呼ぶ）
+export async function setArticleUnlocked(articleID: string): Promise<void> {
+  const store = await cookies()
+  const signature = await sign(articleID)
+  store.set(cookieName(articleID), signature, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: `/blog/${articleID}`,
+    maxAge: MAX_AGE,
+  })
+}

--- a/pages/lib/secret_unlock.ts
+++ b/pages/lib/secret_unlock.ts
@@ -5,6 +5,7 @@
 
 import { cookies } from 'next/headers'
 import { getSecretArticleCookieKey } from './env'
+import { getCloudflareContext } from '@opennextjs/cloudflare'
 
 const COOKIE_PREFIX = 'secret_unlock_'
 const MAX_AGE = 60 * 60 * 24 * 30 // 30日
@@ -14,7 +15,8 @@ function cookieName(articleID: string) {
 }
 
 async function getSigningKey(): Promise<string> {
-  const key = getSecretArticleCookieKey()
+  const { env } = await getCloudflareContext({ async: true })
+  const key = await getSecretArticleCookieKey(env)
   if (!key) {
     throw new Error('SECRET_ARTICLE_COOKIE_KEY is not set')
   }

--- a/pages/lib/secret_unlock.ts
+++ b/pages/lib/secret_unlock.ts
@@ -36,14 +36,20 @@ async function sign(articleID: string): Promise<string> {
   return bufferToHex(signature)
 }
 
-// 長さ・内容のタイミング差を抑えた文字列比較
-export function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false
-  }
+// 2つの文字列を SHA-256 でダイジェスト化してから定数時間比較する。
+// ダイジェストは常に固定長(32byte)になるため入力長の差がタイミングに出ず、
+// 生の secret_code を直接走査することもない。
+export async function secureEqual(a: string, b: string): Promise<boolean> {
+  const enc = new TextEncoder()
+  const [da, db] = await Promise.all([
+    crypto.subtle.digest('SHA-256', enc.encode(a)),
+    crypto.subtle.digest('SHA-256', enc.encode(b)),
+  ])
+  const ua = new Uint8Array(da)
+  const ub = new Uint8Array(db)
   let result = 0
-  for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  for (let i = 0; i < ua.length; i++) {
+    result |= ua[i] ^ ub[i]
   }
   return result === 0
 }
@@ -57,7 +63,7 @@ export async function isArticleUnlocked(articleID: string): Promise<boolean> {
   }
   try {
     const expected = await sign(articleID)
-    return constantTimeEqual(cookie.value, expected)
+    return await secureEqual(cookie.value, expected)
   } catch {
     return false
   }

--- a/pages/middleware.ts
+++ b/pages/middleware.ts
@@ -2,6 +2,7 @@ import { getCloudflareContext } from '@opennextjs/cloudflare'
 import { NextRequest, NextResponse } from 'next/server'
 import sendLog from './lib/logger'
 import { NextURL } from 'next/dist/server/web/next-url'
+import { getNodeEnv } from './lib/env'
 
 const BOT_PATTERNS: { name: string; pattern: RegExp }[] = [
   { name: 'Googlebot', pattern: /googlebot/i },
@@ -97,6 +98,10 @@ export async function middleware(request: NextRequest) {
 
   try {
     const { env, ctx } = await getCloudflareContext({ async: true })
+    if (getNodeEnv() !== 'production') {
+      console.log('Axiom skipped in non-production environment')
+      return NextResponse.next()
+    }
     const endpoint = await env.AXIOM_ENDPOINT.get()
     const apiToken = await env.AXIOM_APITOKEN.get()
     ctx.waitUntil(sendLog(logObj, endpoint, apiToken))

--- a/pages/wrangler.toml
+++ b/pages/wrangler.toml
@@ -20,7 +20,8 @@ kv_namespaces = [
 secrets_store_secrets = [
     { binding="CLARITY_ID", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="CLARITY_ID" },
     { binding="AXIOM_ENDPOINT", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_ENDPOINT" },
-    { binding="AXIOM_APITOKEN", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_APITOKEN" }
+    { binding="AXIOM_APITOKEN", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_APITOKEN" },
+    { binding="SECRET_ARTICLE_COOKIE_KEY", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="SECRET_ARTICLE_COOKIE_KEY" }
 ]
 
 [dev]
@@ -60,5 +61,6 @@ kv_namespaces = [
 secrets_store_secrets = [
     { binding="CLARITY_ID", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="CLARITY_ID" },
     { binding="AXIOM_ENDPOINT", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_ENDPOINT" },
-    { binding="AXIOM_APITOKEN", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_APITOKEN" }
+    { binding="AXIOM_APITOKEN", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="AXIOM_APITOKEN" },
+    { binding="SECRET_ARTICLE_COOKIE_KEY", store_id="da1dbdf4b4e24ed3b82c0d8e117f09d4", secret_name="SECRET_ARTICLE_COOKIE_KEY" }
 ]

--- a/sns-article-publisher/src/index.ts
+++ b/sns-article-publisher/src/index.ts
@@ -251,6 +251,11 @@ function publishNecessary(bodyJSON: WebhookPayload): boolean {
   if (bodyJSON.api !== 'contents') {
     return false
   }
+  // 限定公開記事（is_secret=true）はSNSへ自動投稿しない
+  if (bodyJSON.contents.new.publishValue.is_secret === true) {
+    console.log('content is secret (is_secret=true). skip publish')
+    return false
+  }
   return (
     bodyJSON.type === 'new' ||
     (bodyJSON.type === 'edit' && isDraftToPublish(bodyJSON.contents.old, bodyJSON.contents.new))


### PR DESCRIPTION
## 概要

ブログCMSに追加した `is_secret` / `secret_code` を用いた**限定公開記事**の管理体制を実装します。一覧非表示（Phase1: development 済み）に続き、本PRで閲覧ゲート・各種漏洩経路の対策を追加します。

## 含まれる変更

### A. 記事閲覧ゲート
- 限定公開記事は本文を出さず**閲覧コード入力フォーム**を表示（RSC条件描画）
- コード照合は**サーバ側**（Server Action）で実施し、一致時に**署名付きCookie**を発行 → 以降は再入力不要
- `secret_code` 照合用メタ取得 `fetchSecretMeta` RPC を追加（`secret_code` はクライアント非公開・KV非キャッシュ）
- `draftKey` プレビューはゲートをバイパス
- コード入力欄はパスワードマネージャ保存を避けるため `type="text"`、任意のマスク切り替えボタン付き

### B. キャッシュ
- 限定公開記事は単体KV（`content_{id}`）にキャッシュしない
- `is_secret` トグル時に一覧キャッシュ（`contents_*`）をパージ（cms-cache-purger）

### C. SNS自動投稿
- 限定公開記事は SNS 自動投稿の対象外（`publishNecessary` でスキップ）

### E. リンクカード
- 限定公開記事への内部リンクカードは常にマスク表示（ロック＋タイトル、サムネ・日付は非表示）

### F / OGP・SEO
- webhook型 `ContentValue` に `is_secret` 追加
- 記事ページ・画像サブページの OGP を伏せ（description=「限定公開記事です」、デフォルト画像、`noindex`）。タイトルは公開のまま

## 漏洩経路の対応状況
一覧（Phase1）／SNS自動投稿／閲覧ゲート／KVキャッシュ／OGP・noindex／リンクカード／画像サブページ を一通り対応。

## 検証
- 各ワークスペースの `tsc --noEmit` 通過
- `next build` 成功（`/blog/[article_id]` 含む全ルート生成）

## ⚠️ デプロイ時の必須作業
- 本番 **Secrets Store に `SECRET_ARTICLE_COOKIE_KEY` を登録**（未登録だと解錠Cookieを発行できない）
- microCMS の `contents` に `is_secret` / `secret_code` フィールドが存在すること
- cms-data-fetcher / pages / sns-article-publisher / cms-cache-purger の再デプロイ
- 既存 `contents_*` / 該当 `content_{id}` の手動パージ
- `is_secret[not_equals]true` が未設定の旧記事を取りこぼさないか実機確認
- is_secret トグル・コード解錠の実機動作確認

## 備考
- テストは本PRでは見送り（後続）
- `lint:page` は Next16＋ESLint10 の不整合で別途要対応（本機能とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
