### PR TITLE
限定公開記事の鍵周り対策（draftKey回避の修正・解錠Cookieのsecret_code紐付け）

### DIFF
--- a/pages/app/blog/[article_id]/actions.ts
+++ b/pages/app/blog/[article_id]/actions.ts
@@ -28,7 +28,7 @@ export async function unlockSecretArticle(
     return { ok: false, error: 'コードが違います' }
   }
 
-  await setArticleUnlocked(articleID)
+  await setArticleUnlocked(articleID, meta.secret_code)
   revalidatePath(`/blog/${articleID}`)
   return { ok: true }
 }

--- a/pages/app/blog/[article_id]/article.tsx
+++ b/pages/app/blog/[article_id]/article.tsx
@@ -15,8 +15,8 @@ export default async function BlogPageArticle({
 }) {
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
 
-  // 限定公開記事はコード解錠まで本文を出さない（draftKey でのプレビューはバイパス）
-  if (content.is_secret && draftKey === undefined && !(await isArticleUnlocked(articleID))) {
+  // 限定公開記事はコード解錠まで本文を出さない（draftKey の有無に関わらずパスフレーズを要求する）
+  if (content.is_secret && !(await isArticleUnlocked(articleID))) {
     return (
       <div>
         <SecretGate articleID={content.id} title={content.title} />

--- a/pages/app/blog/[article_id]/article.tsx
+++ b/pages/app/blog/[article_id]/article.tsx
@@ -18,6 +18,15 @@ export default async function BlogPageArticle({
   // 限定公開記事はコード解錠まで本文を出さない（draftKey の有無に関わらずパスフレーズを要求する）
   // 解錠 Cookie は現在の secret_code に紐付けて検証するため、パスフレーズ変更時は自動的に失効する
   if (content.is_secret) {
+    const store = await (await import('next/headers')).cookies()
+    if (!store.get(`secret_unlock_${articleID}`)) {
+      // 解錠 Cookie がない場合は即座に SecretGate を出す（Cookie の有無で高速に分岐させる）
+      return (
+        <div>
+          <SecretGate articleID={content.id} title={content.title} />
+        </div>
+      )
+    }
     const meta = await getSecretMeta(articleID)
     if (!(await isArticleUnlocked(articleID, meta.secret_code ?? ''))) {
       return (

--- a/pages/app/blog/[article_id]/article.tsx
+++ b/pages/app/blog/[article_id]/article.tsx
@@ -1,5 +1,5 @@
 import { FullArticle } from '@/components/large/article'
-import { getCMSContent } from '@/lib/api/workers'
+import { getCMSContent, getSecretMeta } from '@/lib/api/workers'
 import { isArticleUnlocked } from '@/lib/secret_unlock'
 import { contentsAPIResult } from 'api-types'
 import SecretGate from './secret_gate'
@@ -16,12 +16,16 @@ export default async function BlogPageArticle({
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
 
   // 限定公開記事はコード解錠まで本文を出さない（draftKey の有無に関わらずパスフレーズを要求する）
-  if (content.is_secret && !(await isArticleUnlocked(articleID))) {
-    return (
-      <div>
-        <SecretGate articleID={content.id} title={content.title} />
-      </div>
-    )
+  // 解錠 Cookie は現在の secret_code に紐付けて検証するため、パスフレーズ変更時は自動的に失効する
+  if (content.is_secret) {
+    const meta = await getSecretMeta(articleID)
+    if (!(await isArticleUnlocked(articleID, meta.secret_code ?? ''))) {
+      return (
+        <div>
+          <SecretGate articleID={content.id} title={content.title} />
+        </div>
+      )
+    }
   }
 
   return (

--- a/pages/app/blog/[article_id]/image/[src]/page.tsx
+++ b/pages/app/blog/[article_id]/image/[src]/page.tsx
@@ -21,8 +21,8 @@ export async function generateMetadata(props: {
 
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
 
-  // 限定公開記事（未解錠）は本文をメタに出さず、検索インデックスも避ける（page.tsx と同様）
-  const isSecretLocked = content.is_secret === true && draftKey === undefined
+  // 限定公開記事は本文をメタに出さず、検索インデックスも避ける（page.tsx と同様、draftKey ではバイパスさせない）
+  const isSecretLocked = content.is_secret === true
 
   const ogpImage = content.ogp_image
   const ogpURL = getOGPImageURL(isSecretLocked || !ogpImage ? getDefaultOGPImageURL() : ogpImage)

--- a/pages/app/blog/[article_id]/page.tsx
+++ b/pages/app/blog/[article_id]/page.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata(props: {
 
   const content: contentsAPIResult = await getCMSContent(articleID, draftKey)
 
-  // 限定公開記事（未解錠）は本文をメタに出さず、検索インデックスも避ける
-  const isSecretLocked = content.is_secret === true && draftKey === undefined
+  // 限定公開記事は本文をメタに出さず、検索インデックスも避ける（draftKey ではバイパスさせない）
+  const isSecretLocked = content.is_secret === true
 
   const ogpImage = content.ogp_image
   const ogpSrc =

--- a/pages/lib/secret_unlock.ts
+++ b/pages/lib/secret_unlock.ts
@@ -1,7 +1,8 @@
 // 限定公開記事の「解錠状態」を署名付き Cookie で保持するためのサーバ専用ユーティリティ
-//   - Cookie 値は HMAC-SHA256(articleID, SECRET_ARTICLE_COOKIE_KEY) の hex
+//   - Cookie 値は HMAC-SHA256(`${articleID}:${secret_code}`, SECRET_ARTICLE_COOKIE_KEY) の hex
 //   - 解錠時に発行し、以降の閲覧は Cookie 検証のみで本文を表示する（コード再入力不要）
-//   - secret_code そのものは Cookie に保存しない（解錠の瞬間だけ照合に使う）
+//   - secret_code を署名対象に含めるため、パスフレーズ変更時は既存 Cookie が自動的に無効化される
+//   - secret_code そのものは Cookie に保存しない（HMAC 経由でのみ反映する）
 
 import { cookies } from 'next/headers'
 import { getSecretArticleCookieKey } from './env'
@@ -29,10 +30,13 @@ function bufferToHex(buf: ArrayBuffer): string {
     .join('')
 }
 
-async function sign(articleID: string): Promise<string> {
+async function sign(articleID: string, secretCode: string): Promise<string> {
   const keyData = new TextEncoder().encode(await getSigningKey())
   const cryptoKey = await crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
-  const signature = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(articleID))
+  // articleID と secret_code の両方を署名対象にすることで、パスフレーズ変更時に既存 Cookie を失効させる。
+  // articleID は CMS のコンテンツ ID（コロンを含まない）のため `:` を区切りに使っても一意性は保たれる。
+  const message = `${articleID}:${secretCode}`
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(message))
   return bufferToHex(signature)
 }
 
@@ -54,15 +58,15 @@ export async function secureEqual(a: string, b: string): Promise<boolean> {
   return result === 0
 }
 
-// 対象記事が解錠済み（有効な署名 Cookie を持つ）かどうか
-export async function isArticleUnlocked(articleID: string): Promise<boolean> {
+// 対象記事が解錠済み（現在の secret_code に対応する有効な署名 Cookie を持つ）かどうか
+export async function isArticleUnlocked(articleID: string, secretCode: string): Promise<boolean> {
   const store = await cookies()
   const cookie = store.get(cookieName(articleID))
   if (!cookie) {
     return false
   }
   try {
-    const expected = await sign(articleID)
+    const expected = await sign(articleID, secretCode)
     return await secureEqual(cookie.value, expected)
   } catch {
     return false
@@ -70,9 +74,9 @@ export async function isArticleUnlocked(articleID: string): Promise<boolean> {
 }
 
 // 対象記事を解錠済みにする署名 Cookie を発行する（Server Action / Route Handler からのみ呼ぶ）
-export async function setArticleUnlocked(articleID: string): Promise<void> {
+export async function setArticleUnlocked(articleID: string, secretCode: string): Promise<void> {
   const store = await cookies()
-  const signature = await sign(articleID)
+  const signature = await sign(articleID, secretCode)
   store.set(cookieName(articleID), signature, {
     httpOnly: true,
     secure: true,


### PR DESCRIPTION
## 概要

限定公開記事（`is_secret`）の鍵周りの脆弱性を2点修正します。

## 1. draftKey によるパスフレーズ回避の修正

`?draftKey=`（空文字を含む任意値）を URL に付与すると、解錠コード無しで限定公開記事の本文・メタデータが閲覧できる問題を修正。

- **原因**: ゲート判定が `draftKey === undefined` を認可境界に使っていた。`draftKey` はユーザが URL で自由に指定でき、特に空文字は「アプリ側では定義済み扱い→ゲート通過」「CMS 側では未指定扱い→公開本文を返す」というズレで本文が漏洩していた（実環境で再現確認済み）。
- **修正**: `is_secret` が true の場合は **draftKey の有無に関わらず**パスフレーズ解錠を要求。本文ゲート（`article.tsx`）とメタデータ（`page.tsx` / 画像サブページ）の両方を修正。

## 2. パスフレーズ変更時に解錠 Cookie を失効させる

旧実装では解錠 Cookie の署名が `HMAC(articleID)` で secret_code に依存せず、パスフレーズを変更しても既存 Cookie が期限（30日）まで有効だった。

- **修正**: 署名対象を `` `${articleID}:${secret_code}` `` に変更。パスフレーズ変更時に期待署名が変わり、既存 Cookie が自動失効する。検証側ゲートは `getSecretMeta`（skipCache で常に最新）で現在の secret_code を取得して照合。

## 変更ファイル

- `pages/app/blog/[article_id]/article.tsx` — 本文ゲートを draftKey 非依存化＋secret_code 紐付け検証
- `pages/app/blog/[article_id]/page.tsx` — メタデータの secret ロックを draftKey 非依存化
- `pages/app/blog/[article_id]/image/[src]/page.tsx` — 画像サブページのメタデータも同様に修正
- `pages/app/blog/[article_id]/actions.ts` — 解錠 Cookie 発行時に secret_code を渡す
- `pages/lib/secret_unlock.ts` — 署名対象に secret_code を含める

## デプロイ時の注意（一度だけ）

署名方式の変更に伴い、現在解錠済みの全ユーザの既存 Cookie が一斉に無効化されます。デプロイ後、各記事で1回だけパスフレーズの再入力が必要になります。

## 確認

- `tsc --noEmit` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)