### PR TITLE
リーダーモードで中華フォントになる問題を修正 (#1068)

### DIFF
--- a/pages/app/layout.tsx
+++ b/pages/app/layout.tsx
@@ -70,6 +70,7 @@ export default async function RootLayout({ children, drawer }: { children: React
               `}
       </Script>
       <body
+        lang="ja"
         className={cn(
           'min-h-screen antialiased bg-gray-300',
           fontMPlus1.className,

--- a/pages/components/large/article.tsx
+++ b/pages/components/large/article.tsx
@@ -28,7 +28,7 @@ type FullArticleProps = ArticleProps & {
 
 export async function Article({ id, title, updatedAt, parsedContents, categories }: ArticleProps) {
   return (
-    <Card key={id} className="bg-gray-100">
+    <Card key={id} lang="ja" className="bg-gray-100">
       <CardHeader>
         <CardTitleH1>
           <Link href={`blog/${id}`} className="hover:underline">
@@ -71,7 +71,7 @@ export async function FullArticle({
   annotations,
 }: FullArticleProps) {
   return (
-    <Card className="w-full bg-gray-100">
+    <Card lang="ja" className="w-full bg-gray-100">
       <CardHeader>
         <CardTitleH1>{title}</CardTitleH1>
         <CardDescription>

--- a/pages/components/middle/article_content/index.tsx
+++ b/pages/components/middle/article_content/index.tsx
@@ -16,7 +16,7 @@ export default async function ArticleContent({
   const className = sampleFlag ? sampleClassName : contentClassName
 
   return (
-    <div className={cn(className, 'px-2 lg:px-6')}>
+    <div lang="ja" className={cn(className, 'px-2 lg:px-6')}>
       {contents.map((content, index) => {
         if (sampleFlag && index > maxSampleContentCount) {
           return null


### PR DESCRIPTION
## 概要
iPad Safari のリーダーモードで本文が中華フォント（CJK の中国語字形）で表示される問題 (#1068) を修正します。

## 原因
Safari のリーダーモードは本文を別ドキュメントとして再構築するため、最上位の `<html lang="ja">` を参照しません。抽出対象となる本文要素側に `lang` 指定がないと、CJK 文字が中国語字形でレンダリングされます（issue のオーナーコメントの見立て通り）。

## 対応
Safari が本文として抽出しうる各階層に `lang="ja"` を重ねて付与しました。

- `app/layout.tsx`: `<body>` に `lang="ja"`
- `components/large/article.tsx`: `FullArticle` / `Article` の記事ラッパー `Card` に `lang="ja"`（タイトル `h1` を含む記事全体をカバー）
- `components/middle/article_content/index.tsx`: 本文 `<div className="content">` に `lang="ja"`（リーダーが本文として抽出する核）

`lang` は `body` / `div` および `Card`（`HTMLAttributes` を forward）で有効な属性のため型エラーはありません。

## 確認事項
- 本不具合は iPad Safari のリーダーモード固有のため、デプロイ後（STG など）に **iPad Safari のリーダー表示** で中華フォントが解消されたか実機確認が必要です。

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)