### PR TITLE
feat(e2e): deploy_stg 完了後の staging E2E テストを追加

### DIFF
--- a/.github/workflows/deploy_stg.yaml
+++ b/.github/workflows/deploy_stg.yaml
@@ -246,3 +246,42 @@ jobs:
           echo "cms cache result: $cms_cache_result"
           echo "sns result: $sns_result"
           exit 1
+
+  e2e:
+    # status ジョブ成功（= どのデプロイも failure でない）時のみ実行する。
+    # デプロイ失敗時は needs 不成立で自動 skip され、差分の有無に依存せず常時実行される。
+    needs: [status]
+    runs-on: ubuntu-latest
+    environment:
+      name: stg
+    env:
+      E2E_BASE_URL: ${{ vars.E2E_BASE_URL || 'https://maretol-base-v3-stg.maretol-ruha.workers.dev' }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: npm ci
+        run: npm ci
+      - name: resolve playwright version
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: cache playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+      - name: install playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: run e2e tests
+        run: npm run test:e2e
+      - name: upload playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 14

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+playwright/.cache/
+.cache/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,64 @@
+import { requireBaseURL, SITE_LOGO_ALT } from './lib/constants'
+
+// デプロイ反映待ち（readiness）。
+// テスト本体の実行前に、既存トップページ（/）へ正常応答（2xx）かつ共通シェルの既知マーカーが
+// 返るまでポーリングして待機する。App Router のストリーミング SSR により、CMS 本文が
+// suspend 中でもシェル（ヘッダー/フッター）を含む 2xx が即時返るため、既存ページでも
+// 安定した疎通判定点になる。
+
+const READINESS_INTERVAL_MS = 5_000
+const READINESS_TIMEOUT_MS = 180_000
+
+interface ReadinessOptions {
+  url: string
+  marker: string
+  intervalMs: number
+  timeoutMs: number
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function probeOnce(url: string, marker: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { redirect: 'follow' })
+    if (!res.ok) {
+      return false
+    }
+    const body = await res.text()
+    return body.includes(marker)
+  } catch {
+    // 接続不可・DNS 未伝播などは未達として扱い、リトライを続ける。
+    return false
+  }
+}
+
+async function waitForStagingReady(options: ReadinessOptions): Promise<void> {
+  const { url, marker, intervalMs, timeoutMs } = options
+  const deadline = Date.now() + timeoutMs
+
+  // 規定間隔でポーリングし、2xx かつマーカー確認で成功。タイムアウトで throw。
+  for (;;) {
+    if (await probeOnce(url, marker)) {
+      // eslint-disable-next-line no-console
+      console.log(`[readiness] staging is ready: ${url}`)
+      return
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`[readiness] staging did not become ready within ${timeoutMs}ms: ${url}`)
+    }
+    await sleep(intervalMs)
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  const baseURL = requireBaseURL()
+  const target = new URL('/', baseURL).toString()
+  await waitForStagingReady({
+    url: target,
+    marker: SITE_LOGO_ALT,
+    intervalMs: READINESS_INTERVAL_MS,
+    timeoutMs: READINESS_TIMEOUT_MS,
+  })
+}

--- a/e2e/lib/constants.ts
+++ b/e2e/lib/constants.ts
@@ -1,0 +1,27 @@
+// E2E テスト全体で共有する定数・ヘルパ。
+// マーカーや対象ルートを単一箇所で管理し、テストと readiness の間で drift を防ぐ。
+
+// 主要ルート共通シェル（BaseLayout / BlogLayout の双方）が描画するヘッダーロゴの alt。
+// readiness マーカーおよびスモークのランドマークとして利用する。
+export const SITE_LOGO_ALT = 'Maretol Base'
+
+// スモークテストで巡回する既存の主要ルート。
+export const MAIN_ROUTES = ['/', '/blog', '/illust', '/comics', '/about', '/contact', '/tag'] as const
+
+// 404 検証用の、存在しないことが期待されるパス。
+export const NOT_FOUND_PATH = '/__e2e_nonexistent_path__'
+
+// フィード（RSS / sitemap）の検証対象パスと、本文に含まれるべきルート要素。
+export const RSS_FEED_PATH = '/rss/feed.rdf'
+export const RSS_ROOT_ELEMENT = '<rss'
+export const SITEMAP_PATH = '/sitemap.xml'
+export const SITEMAP_ROOT_ELEMENT = '<urlset'
+
+// base URL を環境変数から取得する。未設定なら明示的なエラーで停止（fail-fast）。
+export function requireBaseURL(): string {
+  const baseURL = process.env.E2E_BASE_URL
+  if (!baseURL) {
+    throw new Error('E2E_BASE_URL is not set')
+  }
+  return baseURL
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "staging 環境に対する E2E テスト（Playwright）",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices, type ReporterDescription } from '@playwright/test'
+import { requireBaseURL } from './lib/constants'
+
+// base URL は E2E_BASE_URL から取得（未設定なら requireBaseURL が throw して即時停止）。
+const baseURL = requireBaseURL()
+
+const isCI = !!process.env.CI
+
+// レポータ: 常に list + HTML。CI では GitHub アノテーションも付与する。
+const reporter: ReporterDescription[] = isCI
+  ? [['list'], ['html', { open: 'never' }], ['github']]
+  : [['list'], ['html', { open: 'never' }]]
+
+export default defineConfig({
+  testDir: './tests',
+  // デプロイ反映待ち（readiness）をテスト本体の前に実行する。
+  globalSetup: './global-setup.ts',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  // CI 前提の余裕を持ったタイムアウト。無限待機を避ける。
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  // 一時的なネットワーク/描画遅延を自動リトライで吸収（ローカルは 0）。
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 2 : undefined,
+  reporter,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  // 初期は Chromium のみ。外部デプロイ済み URL 対象のため webServer は使用しない。
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})

--- a/e2e/tests/feeds.spec.ts
+++ b/e2e/tests/feeds.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+import { RSS_FEED_PATH, RSS_ROOT_ELEMENT, SITEMAP_PATH, SITEMAP_ROOT_ELEMENT } from '../lib/constants'
+
+// フィード（RSS / sitemap）の検証。
+// ブラウザ描画は不要なため request コンテキストで取得する。
+// content-type ヘッダ設定の有無には依存せず、status 200 + 本文のルート要素で判定する
+// （RSS ルートは content-type を正しく設定していないため、ヘッダ非依存とする）。
+test('rss feed responds with rss root element', async ({ request }) => {
+  const response = await request.get(RSS_FEED_PATH)
+  expect(response.status()).toBe(200)
+  const body = await response.text()
+  expect(body).toContain(RSS_ROOT_ELEMENT)
+})
+
+test('sitemap responds with urlset root element', async ({ request }) => {
+  const response = await request.get(SITEMAP_PATH)
+  expect(response.status()).toBe(200)
+  const body = await response.text()
+  expect(body).toContain(SITEMAP_ROOT_ELEMENT)
+})

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+
+// ブログ一覧から記事詳細への遷移テスト。
+// 一覧から実在の記事リンクを取得し（IDはハードコードしない）、遷移先で記事詳細が描画されることを確認する。
+test('navigates from blog list to an article detail', async ({ page }) => {
+  await page.goto('/blog', { waitUntil: 'domcontentloaded' })
+
+  // 記事詳細リンク（/blog/<id>）。一覧本文のカードタイトル等が該当する。
+  const articleLinks = page.locator('a[href^="/blog/"]')
+  const firstArticle = articleLinks.first()
+  await firstArticle.waitFor({ state: 'visible' })
+
+  // 一覧項目が1件以上存在すること（特定タイトル等の内容には依存しない）。
+  expect(await articleLinks.count()).toBeGreaterThan(0)
+
+  await firstArticle.click()
+
+  // 実在記事の詳細ページへ遷移し、見出し（h1 タイトル）が描画されること。
+  await expect(page).toHaveURL(/\/blog\/.+/)
+  await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
+})

--- a/e2e/tests/secret.spec.ts
+++ b/e2e/tests/secret.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+// 限定公開記事（cookie 認証）の検証（任意・既定スキップ）。
+//   - 解錠 Cookie は `secret_unlock_<articleID>`（HMAC 署名値, path=`/blog/<articleID>`）。
+//   - 署名の再現には鍵と secret_code が必要なため、Cookie 値は CI 外で事前計算し、
+//     `E2E_SECRET_COOKIE` として注入する（秘匿値はログ/成果物へ出力しない）。
+//   - 必要な情報が未設定の場合は test.skip でスキップする。
+const secretCookie = process.env.E2E_SECRET_COOKIE
+const secretArticleId = process.env.E2E_SECRET_ARTICLE_ID
+
+test('locked article shows protected content when unlock cookie is provided', async ({ page, context, baseURL }) => {
+  test.skip(
+    !secretCookie || !secretArticleId,
+    'E2E_SECRET_COOKIE / E2E_SECRET_ARTICLE_ID が未設定のため、限定公開記事の認証テストをスキップします',
+  )
+
+  const hostname = new URL(baseURL as string).hostname
+  const path = `/blog/${secretArticleId}`
+
+  await context.addCookies([
+    {
+      name: `secret_unlock_${secretArticleId}`,
+      value: secretCookie as string,
+      domain: hostname,
+      path,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+    },
+  ])
+
+  const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+  expect(response, 'no response for locked article').not.toBeNull()
+  expect(response!.ok()).toBeTruthy()
+
+  // 解錠済みとして本文（記事見出し）が表示されること。
+  await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
+})

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+import { MAIN_ROUTES, NOT_FOUND_PATH, SITE_LOGO_ALT } from '../lib/constants'
+
+// 主要ルートのスモークテスト。
+// 各ルートが 2xx で応答し、共通ランドマーク（ヘッダーロゴ）が描画されることを確認する。
+// アサーションは構造/存在ベースとし、変動しうる具体テキストへの完全一致依存は避ける。
+for (const route of MAIN_ROUTES) {
+  test(`main route responds and renders: ${route}`, async ({ page }) => {
+    const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
+    expect(response, `no response for ${route}`).not.toBeNull()
+    expect(response!.ok(), `unexpected status ${response!.status()} for ${route}`).toBeTruthy()
+
+    // 共通シェルのロゴが可視であることのみを確認（CMS 由来の変動テキストには依存しない）。
+    await expect(page.getByAltText(SITE_LOGO_ALT).first()).toBeVisible()
+  })
+}
+
+test('unknown path returns 404', async ({ page }) => {
+  const response = await page.goto(NOT_FOUND_PATH, { waitUntil: 'domcontentloaded' })
+  expect(response, 'no response for unknown path').not.toBeNull()
+  expect(response!.status()).toBe(404)
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "ogp-data-fetcher",
         "packages/*",
         "cms-cache-purger",
-        "sns-article-publisher"
+        "sns-article-publisher",
+        "e2e"
       ],
       "devDependencies": {
         "esbuild": "0.28.1"
@@ -43,6 +44,12 @@
         "typescript": "^6.0.2",
         "vitest": "4.1.9",
         "wrangler": "^4.105.0"
+      }
+    },
+    "e2e": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2759,9 +2766,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2777,9 +2781,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2797,9 +2798,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,9 +2813,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3592,6 +3587,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -4395,9 +4406,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4415,9 +4423,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4435,9 +4440,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4455,9 +4457,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4475,9 +4474,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4495,9 +4491,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5311,9 +5304,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5331,9 +5321,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5351,9 +5338,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5371,9 +5355,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7540,6 +7521,10 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
+    },
+    "node_modules/e2e": {
+      "resolved": "e2e",
+      "link": true
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
@@ -11322,6 +11307,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:page": "npm run --workspace=pages pages:build",
     "lint:page": "npm run --workspace=pages lint",
     "test:cms": "npm run --workspace=cms-data-fetcher test",
-    "test:sns": "npm run --workspace=sns-article-publisher test"
+    "test:sns": "npm run --workspace=sns-article-publisher test",
+    "test:e2e": "npm run --workspace=e2e test:e2e"
   },
   "author": "maretol",
   "private": true,
@@ -30,7 +31,8 @@
     "ogp-data-fetcher",
     "packages/*",
     "cms-cache-purger",
-    "sns-article-publisher"
+    "sns-article-publisher",
+    "e2e"
   ],
   "devDependencies": {
     "esbuild": "0.28.1"


### PR DESCRIPTION
## 概要
`deploy_stg`（staging デプロイCI）の完了後に、staging 環境へ Playwright で E2E テストを自動実行する CI 環境を追加します。デプロイ後の主要導線の破損を早期検知することが目的です。

## 変更点
- **e2e ワークスペース新設**（`@playwright/test`, Chromium）。ルート `workspaces` と `test:e2e` スクリプトを追加。
- **テスト実装（既存ページ対象）**
  - スモーク: 主要7ルート（`/`, `/blog`, `/illust`, `/comics`, `/about`, `/contact`, `/tag`）の 2xx + 共通ランドマーク描画、および 404
  - ナビゲーション: ブログ一覧 → 記事詳細への遷移（実在IDを一覧から取得）
  - フィード: `/rss/feed.rdf`・`/sitemap.xml` の 200 + 本文ルート要素（content-type 非依存）
  - 認証（任意・既定 skip）: 限定公開記事の解錠 Cookie 注入
- **readiness**: `globalSetup` で既存トップページを 2xx + 共通シェルのマーカー（`Maretol Base`）でポーリングし、デプロイ伝播を待機（タイムアウト 180s）。
- **CI 統合**: `deploy_stg.yaml` に `e2e` ジョブを追加。
  - `needs: [status]`：デプロイ失敗時は自動 skip、差分に依存せず常時実行
  - `environment: stg`、`E2E_BASE_URL` 注入、Playwright ブラウザキャッシュ、`--with-deps chromium`
  - 成功/失敗いずれも report・trace 等を artifact 保存（保持14日）

## 設計方針
- CMS データ変動に強い「ゆるい」アサーション（存在・件数≥1・ステータス中心、具体テキスト非依存）。
- 外部デプロイ済み URL 対象のため `webServer` 不使用、`E2E_BASE_URL` 未設定時は fail-fast。
- 検証専用ページは新設せず既存ページに対して実行。

## 検証状況
- fail-fast / spec 検出（12テスト）/ TypeScript strict 型チェック: OK
- 実 staging に対し readiness 通過・フィードテスト2件 PASS、その他アサーションも curl で実 staging と一致を確認
- ブラウザ実行テストは本 PR の CI（`--with-deps` で OS 依存導入）で実行されます

## 既知の制約
- `deploy_stg` は各PRで同一 staging worker にデプロイするため、複数PR並行時は共有環境の競合可能性あり（初期は既知の制約として受容）。
- E2E の必須チェック化（branch protection）は運用設定として別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)