### PR TITLE
fix(cms): CodeQLセキュリティ指摘の対応（#1111）

### DIFF
--- a/cms-db/scripts/export_microcms.ts
+++ b/cms-db/scripts/export_microcms.ts
@@ -77,7 +77,8 @@ if (!target) {
 }
 const apiKey = process.env[target.apiKeyEnv]
 if (!apiKey) {
-  console.error(`環境変数 ${target.apiKeyEnv} が設定されていません`)
+  // APIキー関連の値をログに含めない（CodeQL: clear-text logging対策で静的メッセージとする）
+  console.error('microCMS APIキーの環境変数が未設定です（illust: CMS_API_KEY_AT / comic: CMS_API_KEY_BD / blog: CMS_API_KEY）')
   process.exit(1)
 }
 

--- a/packages/md-converter/src/index.ts
+++ b/packages/md-converter/src/index.ts
@@ -91,7 +91,8 @@ function createConverter(): MarkdownIt {
 
   // cite:: 行の保護: 引用元記法 cite::[タイトル](URL) は pages 側が「生テキスト」を
   // 正規表現で解釈するため、Markdown のリンク記法として <a> に変換されると URL が失われる。
-  // cite:: で始まる行は [ をエスケープしてリンク解釈を抑止し、リテラルのまま出力する
+  // cite:: で始まる行は \ と [ をエスケープしてリンク解釈を抑止し、リテラルのまま出力する
+  // （\ を先にエスケープしないと、入力中の「\[」が「\\[」となりリンク解釈の抑止をすり抜ける）
   md.core.ruler.before('inline', 'cms_protect_cite', (state) => {
     for (const token of state.tokens) {
       if (token.type !== 'inline' || !token.content.includes('cite::')) {
@@ -99,7 +100,9 @@ function createConverter(): MarkdownIt {
       }
       token.content = token.content
         .split('\n')
-        .map((line) => (line.trimStart().startsWith('cite::') ? line.replace(/\[/g, '\\[') : line))
+        .map((line) =>
+          line.trimStart().startsWith('cite::') ? line.replace(/\\/g, '\\\\').replace(/\[/g, '\\[') : line
+        )
         .join('\n')
     }
   })

--- a/packages/md-converter/test/convert.spec.ts
+++ b/packages/md-converter/test/convert.spec.ts
@@ -151,4 +151,12 @@ describe('基本記法', () => {
     const html = convertMarkdownToHtml('これは[リンク](https://example.com)です')
     expect(html).toBe('<p>これは<a href="https://example.com">リンク</a>です</p>\n')
   })
+
+  it('cite::行にバックスラッシュが含まれてもリンク解釈の抑止をすり抜けない', () => {
+    // 「\[」を含む入力: \ を先にエスケープしないと「\\[」となり [x](y) がリンク化してしまう
+    const md = '> 引用\n> cite::\\[タイトル](https://example.com)'
+    const html = convertMarkdownToHtml(md)
+    expect(html).not.toContain('<a href')
+    expect(html).toContain('cite::\\[タイトル](https://example.com)')
+  })
 })


### PR DESCRIPTION
## 概要

development → main のPR #1111 に付いた CodeQL の指摘2件への対応です。

## 修正内容

### 1. Incomplete string escaping or encoding（packages/md-converter/src/index.ts）

cite:: 行のリンク解釈抑止で `[` のみエスケープしており、入力に `\[` が含まれると `\\[` となって抑止をすり抜け、`[タイトル](URL)` がリンク化してしまう問題。**バックスラッシュを先にエスケープする**よう修正し、回帰テストを追加しました。

### 2. Clear-text logging of sensitive information（cms-db/scripts/export_microcms.ts）

APIキーの環境変数名をエラーメッセージに変数展開していた箇所です（値そのものは出力していませんが、キー由来の値のログ出力として検知）。**静的メッセージに変更**して解消しました。

## テスト

md-converter 24件 + cms-data-fetcher 68件、すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)