### PR TITLE
feat(admin): 画面の最大幅を拡大（1600px）

### DIFF
--- a/admin-pages/app/layout.tsx
+++ b/admin-pages/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     <html lang="ja">
       <body className="min-h-screen bg-gray-50 text-gray-900">
         <header className="border-b border-gray-200 bg-white">
-          <div className="mx-auto flex max-w-5xl items-center gap-6 px-4 py-3">
+          <div className="mx-auto flex max-w-[1600px] items-center gap-6 px-4 py-3">
             <Link href="/" className="text-lg font-bold">
               Maretol Base CMS Admin
             </Link>
@@ -32,7 +32,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             </nav>
           </div>
         </header>
-        <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+        <main className="mx-auto max-w-[1600px] px-4 py-6">{children}</main>
       </body>
     </html>
   )


### PR DESCRIPTION
## 概要
#1133 の改修項目「画面の最大幅を広くしたい」の対応。

- ヘッダー・メインコンテンツの `max-w-5xl`（1024px）を `max-w-[1600px]` に拡大
- 本文エディタや一覧テーブルが広い画面で使いやすくなります

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)