### PR TITLE
feat(admin): 一覧ページの表示項目を追加

### DIFF
--- a/admin-pages/app/blog/page.tsx
+++ b/admin-pages/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { listBlogContents } from '@/lib/db_blog'
+import { formatJST } from '@/lib/format'
 
 export const dynamic = 'force-dynamic'
 
@@ -37,10 +38,12 @@ export default async function BlogList() {
           <tr className="border-b border-gray-200 text-left text-gray-500">
             <th className="p-2">ID</th>
             <th className="p-2">タイトル</th>
+            <th className="p-2">カテゴリ</th>
             <th className="p-2">状態</th>
             <th className="p-2">限定</th>
             <th className="p-2">形式</th>
             <th className="p-2">公開日時</th>
+            <th className="p-2">更新日時</th>
             <th className="p-2"></th>
           </tr>
         </thead>
@@ -49,10 +52,12 @@ export default async function BlogList() {
             <tr key={a.id} className="border-b border-gray-100">
               <td className="p-2 font-mono text-xs">{a.id}</td>
               <td className="p-2">{a.title}</td>
+              <td className="p-2 text-xs">{a.category_names ?? '-'}</td>
               <td className="p-2">{statusLabel[a.status] ?? a.status}</td>
               <td className="p-2">{a.is_secret === 1 ? '🔒' : ''}</td>
               <td className="p-2 font-mono text-xs">{a.content_format}</td>
-              <td className="p-2 text-xs">{a.published_at ?? '-'}</td>
+              <td className="p-2 text-xs">{formatJST(a.published_at)}</td>
+              <td className="p-2 text-xs">{formatJST(a.updated_at)}</td>
               <td className="p-2">
                 <Link href={`/blog/${a.id}/edit`} className="text-blue-600 underline">
                   編集
@@ -62,7 +67,7 @@ export default async function BlogList() {
           ))}
           {articles.length === 0 && (
             <tr>
-              <td colSpan={7} className="p-4 text-center text-gray-400">
+              <td colSpan={9} className="p-4 text-center text-gray-400">
                 データがありません
               </td>
             </tr>

--- a/admin-pages/app/comic/page.tsx
+++ b/admin-pages/app/comic/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { listBandeDessinees } from '@/lib/db_comic'
+import { formatJST, formatJSTDate } from '@/lib/format'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,9 +35,13 @@ export default async function ComicList() {
           <tr className="border-b border-gray-200 text-left text-gray-500">
             <th className="p-2">ID</th>
             <th className="p-2">タイトル</th>
+            <th className="p-2">タグ</th>
+            <th className="p-2">シリーズ</th>
+            <th className="p-2">発行日</th>
             <th className="p-2">状態</th>
             <th className="p-2">形式</th>
             <th className="p-2">公開日時</th>
+            <th className="p-2">更新日時</th>
             <th className="p-2"></th>
           </tr>
         </thead>
@@ -45,9 +50,13 @@ export default async function ComicList() {
             <tr key={c.id} className="border-b border-gray-100">
               <td className="p-2 font-mono text-xs">{c.id}</td>
               <td className="p-2">{c.title_name}</td>
+              <td className="p-2 text-xs">{c.tag_name ?? '-'}</td>
+              <td className="p-2 text-xs">{c.series_name ?? '-'}</td>
+              <td className="p-2 text-xs">{formatJSTDate(c.publish_date)}</td>
               <td className="p-2">{statusLabel[c.status] ?? c.status}</td>
               <td className="p-2 font-mono text-xs">{c.description_format}</td>
-              <td className="p-2 text-xs">{c.published_at ?? '-'}</td>
+              <td className="p-2 text-xs">{formatJST(c.published_at)}</td>
+              <td className="p-2 text-xs">{formatJST(c.updated_at)}</td>
               <td className="p-2">
                 <Link href={`/comic/${c.id}/edit`} className="text-blue-600 underline">
                   編集
@@ -57,7 +66,7 @@ export default async function ComicList() {
           ))}
           {comics.length === 0 && (
             <tr>
-              <td colSpan={6} className="p-4 text-center text-gray-400">
+              <td colSpan={10} className="p-4 text-center text-gray-400">
                 データがありません
               </td>
             </tr>

--- a/admin-pages/app/illust/page.tsx
+++ b/admin-pages/app/illust/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { listAteliers } from '@/lib/db'
+import { formatJST } from '@/lib/format'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,22 +30,31 @@ export default async function IllustList() {
       <table className="w-full border-collapse bg-white text-sm">
         <thead>
           <tr className="border-b border-gray-200 text-left text-gray-500">
+            <th className="p-2">画像</th>
             <th className="p-2">ID</th>
             <th className="p-2">タイトル</th>
+            <th className="p-2">タグ</th>
             <th className="p-2">状態</th>
             <th className="p-2">形式</th>
             <th className="p-2">公開日時</th>
+            <th className="p-2">更新日時</th>
             <th className="p-2"></th>
           </tr>
         </thead>
         <tbody>
           {ateliers.map((a) => (
             <tr key={a.id} className="border-b border-gray-100">
+              <td className="p-2">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={a.src} alt="" className="h-10 w-10 rounded object-cover" style={{ objectPosition: a.object_position }} />
+              </td>
               <td className="p-2 font-mono text-xs">{a.id}</td>
               <td className="p-2">{a.title}</td>
+              <td className="p-2 text-xs">{a.tag_names ?? '-'}</td>
               <td className="p-2">{statusLabel[a.status] ?? a.status}</td>
               <td className="p-2 font-mono text-xs">{a.description_format}</td>
-              <td className="p-2 text-xs">{a.published_at ?? '-'}</td>
+              <td className="p-2 text-xs">{formatJST(a.published_at)}</td>
+              <td className="p-2 text-xs">{formatJST(a.updated_at)}</td>
               <td className="p-2">
                 <Link href={`/illust/${a.id}/edit`} className="text-blue-600 underline">
                   編集
@@ -54,7 +64,7 @@ export default async function IllustList() {
           ))}
           {ateliers.length === 0 && (
             <tr>
-              <td colSpan={6} className="p-4 text-center text-gray-400">
+              <td colSpan={9} className="p-4 text-center text-gray-400">
                 データがありません
               </td>
             </tr>

--- a/admin-pages/lib/db.ts
+++ b/admin-pages/lib/db.ts
@@ -10,11 +10,19 @@ async function getDB(): Promise<D1Database> {
   return env.DB
 }
 
-export async function listAteliers(): Promise<atelierRow[]> {
+// 一覧表示用: タグ名を連結して付加した行
+export type AtelierListRow = atelierRow & { tag_names: string | null }
+
+export async function listAteliers(): Promise<AtelierListRow[]> {
   const db = await getDB()
   const result = await db
-    .prepare(`SELECT * FROM ateliers ORDER BY created_at DESC`)
-    .all<atelierRow>()
+    .prepare(
+      `SELECT a.*,
+        (SELECT group_concat(t.tag, ', ') FROM atelier_tag_relations r
+          JOIN atelier_tags t ON t.id = r.tag_id WHERE r.atelier_id = a.id) AS tag_names
+       FROM ateliers a ORDER BY a.created_at DESC`
+    )
+    .all<AtelierListRow>()
   return result.results
 }
 

--- a/admin-pages/lib/db_blog.ts
+++ b/admin-pages/lib/db_blog.ts
@@ -12,11 +12,19 @@ async function getDB(): Promise<D1Database> {
 
 // --- 記事（contents） ---
 
-export async function listBlogContents(): Promise<blogContentRow[]> {
+// 一覧表示用: カテゴリ名を連結して付加した行
+export type BlogContentListRow = blogContentRow & { category_names: string | null }
+
+export async function listBlogContents(): Promise<BlogContentListRow[]> {
   const db = await getDB()
   const result = await db
-    .prepare(`SELECT * FROM blog_contents ORDER BY created_at DESC`)
-    .all<blogContentRow>()
+    .prepare(
+      `SELECT c.*,
+        (SELECT group_concat(bc.name, ', ') FROM blog_content_categories r
+          JOIN blog_categories bc ON bc.id = r.category_id WHERE r.content_id = c.id) AS category_names
+       FROM blog_contents c ORDER BY c.created_at DESC`
+    )
+    .all<BlogContentListRow>()
   return result.results
 }
 

--- a/admin-pages/lib/db_comic.ts
+++ b/admin-pages/lib/db_comic.ts
@@ -10,11 +10,20 @@ async function getDB(): Promise<D1Database> {
   return env.DB
 }
 
-export async function listBandeDessinees(): Promise<bandeDessineeRow[]> {
+// 一覧表示用: タグ名・シリーズ名を付加した行
+export type BandeDessineeListRow = bandeDessineeRow & { tag_name: string | null; series_name: string | null }
+
+export async function listBandeDessinees(): Promise<BandeDessineeListRow[]> {
   const db = await getDB()
   const result = await db
-    .prepare(`SELECT * FROM bande_dessinees ORDER BY created_at DESC`)
-    .all<bandeDessineeRow>()
+    .prepare(
+      `SELECT b.*, t.tag_name AS tag_name, s.series_name AS series_name
+       FROM bande_dessinees b
+       LEFT JOIN bande_dessinee_tags t ON t.id = b.tag_id
+       LEFT JOIN bande_dessinee_series s ON s.id = b.series_id
+       ORDER BY b.created_at DESC`
+    )
+    .all<BandeDessineeListRow>()
   return result.results
 }
 

--- a/admin-pages/lib/format.ts
+++ b/admin-pages/lib/format.ts
@@ -1,0 +1,27 @@
+// ISO 8601 UTC のタイムスタンプを一覧表示用のJST文字列（YYYY/MM/DD HH:mm）に変換する
+export function formatJST(iso: string | null | undefined): string {
+  if (!iso) {
+    return '-'
+  }
+  return new Date(iso).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// 発行日など日付のみの表示用（YYYY/MM/DD）
+export function formatJSTDate(iso: string | null | undefined): string {
+  if (!iso) {
+    return '-'
+  }
+  return new Date(iso).toLocaleDateString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}


### PR DESCRIPTION
## 概要
#1133 の改修項目「記事一覧などのページに表示する項目を増やしたい」の対応。

### イラスト一覧
- サムネイル画像（object_position 反映）
- タグ名（カンマ区切り）
- 更新日時

### マンガ一覧
- タグ名・シリーズ名
- 発行日
- 更新日時

### ブログ一覧
- カテゴリ名（カンマ区切り）
- 更新日時

### 共通
- 日時表示を生のISO文字列からJST（YYYY/MM/DD HH:mm）表示に変更（lib/format.ts 追加）
- タグ・カテゴリ名は一覧クエリ側で JOIN / group_concat して取得（N+1なし）

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)