### PR TITLE
feat(admin): 送信中のボタン無効化・処理中表示（二度押し防止）

### DIFF
--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react'
 import type { blogContentRow, blogCategoryRow } from 'api-types'
 import { createBlogContentAction, updateBlogContentAction, previewBlogContentAction } from './actions'
+import { SubmitButton } from '@/components/submit-button'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -144,16 +145,10 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
 
         <div className="space-y-2 border-t border-gray-100 pt-4">
           <div className="flex gap-3">
-            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-              保存
-            </button>
-            <button
-              type="submit"
-              formAction={previewFormAction}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-            >
+            <SubmitButton pendingText="保存中...">保存</SubmitButton>
+            <SubmitButton variant="secondary" formAction={previewFormAction} pendingText="プレビュー保存中...">
               プレビュー保存（D1には保存しない）
-            </button>
+            </SubmitButton>
           </div>
           <label className="flex items-center gap-2 text-xs text-gray-500">
             <input type="checkbox" name="regenerate_draft_key" />

--- a/admin-pages/app/blog/categories/category-order-list.tsx
+++ b/admin-pages/app/blog/categories/category-order-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type { blogCategoryRow } from 'api-types'
 import { updateBlogCategoryOrderAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 // カテゴリの表示順をドラッグ&ドロップ（と↑↓ボタン）で並べ替えるリスト。
 // 並び順は hidden input（order_{id} = index）として送信し、既存のアクションで一括保存する
@@ -73,9 +74,7 @@ export function CategoryOrderList({ categories }: { categories: blogCategoryRow[
         ))}
         {items.length === 0 && <li className="p-4 text-center text-sm text-gray-400">カテゴリがありません</li>}
       </ul>
-      <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-        この並び順で保存
-      </button>
+      <SubmitButton pendingText="保存中...">この並び順で保存</SubmitButton>
       <p className="text-xs text-gray-400">ドラッグ&ドロップまたは↑↓ボタンで並べ替え、保存で確定します</p>
     </form>
   )

--- a/admin-pages/app/blog/categories/page.tsx
+++ b/admin-pages/app/blog/categories/page.tsx
@@ -1,6 +1,7 @@
 import { listBlogCategories } from '@/lib/db_blog'
 import { createBlogCategoryAction } from '../actions'
 import { CategoryOrderList } from './category-order-list'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,9 +29,7 @@ export default async function BlogCategories({ searchParams }: { searchParams: P
             <input name="name" required className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm" />
           </div>
         </div>
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          追加
-        </button>
+        <SubmitButton pendingText="追加中...">追加</SubmitButton>
       </form>
     </div>
   )

--- a/admin-pages/app/blog/info/info-form.tsx
+++ b/admin-pages/app/blog/info/info-form.tsx
@@ -1,5 +1,6 @@
 import type { blogInfoRow } from 'api-types'
 import { createBlogInfoAction, updateBlogInfoAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -82,9 +83,7 @@ export function InfoForm({ mode, info, error, saved }: Props) {
           </select>
         </div>
 
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          保存
-        </button>
+        <SubmitButton pendingText="保存中...">保存</SubmitButton>
       </form>
     </div>
   )

--- a/admin-pages/app/blog/static/page.tsx
+++ b/admin-pages/app/blog/static/page.tsx
@@ -1,5 +1,6 @@
 import { listBlogStatic } from '@/lib/db_blog'
 import { updateBlogStaticAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -32,9 +33,9 @@ export default async function BlogStatic({ searchParams }: { searchParams: Promi
               rows={Math.min(6, Math.max(2, e.value.split('\n').length))}
               className="w-full rounded-md border border-gray-300 p-2 text-sm"
             />
-            <button type="submit" className="rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white hover:bg-gray-700">
+            <SubmitButton size="sm" pendingText="保存中...">
               保存
-            </button>
+            </SubmitButton>
           </form>
         ))}
       </div>

--- a/admin-pages/app/cache/page.tsx
+++ b/admin-pages/app/cache/page.tsx
@@ -1,5 +1,6 @@
 import { getCacheStats, CACHE_GROUPS, type CacheGroupKey } from '@/lib/cache'
 import { purgeCacheGroupAction, purgeAllCacheAction } from './actions'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -49,12 +50,9 @@ export default async function CacheManagement({
               <td className="p-2">
                 <form action={purgeCacheGroupAction}>
                   <input type="hidden" name="group" value={key} />
-                  <button
-                    type="submit"
-                    className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100"
-                  >
+                  <SubmitButton variant="secondary" size="sm" pendingText="パージ中...">
                     パージ
-                  </button>
+                  </SubmitButton>
                 </form>
               </td>
             </tr>
@@ -63,9 +61,9 @@ export default async function CacheManagement({
       </table>
 
       <form action={purgeAllCacheAction}>
-        <button type="submit" className="rounded-md bg-red-700 px-4 py-2 text-sm text-white hover:bg-red-600">
+        <SubmitButton variant="danger" pendingText="パージ中...">
           すべてパージ
-        </button>
+        </SubmitButton>
         <p className="mt-1 text-xs text-gray-400">
           全キャッシュを削除します。直後のアクセスはD1への取得が発生しますが表示への影響はありません
         </p>

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react'
 import type { bandeDessineeRow, bandeDessineeTagRow, bandeDessineeSeriesRow } from 'api-types'
 import { createBandeDessineeAction, updateBandeDessineeAction, previewBandeDessineeAction } from './actions'
+import { SubmitButton } from '@/components/submit-button'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -210,16 +211,10 @@ export function ComicForm({ mode, comic, allTags, allSeries, error, saved }: Pro
 
         <div className="space-y-2 border-t border-gray-100 pt-4">
           <div className="flex gap-3">
-            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-              保存
-            </button>
-            <button
-              type="submit"
-              formAction={previewFormAction}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-            >
+            <SubmitButton pendingText="保存中...">保存</SubmitButton>
+            <SubmitButton variant="secondary" formAction={previewFormAction} pendingText="プレビュー保存中...">
               プレビュー保存（D1には保存しない）
-            </button>
+            </SubmitButton>
           </div>
           <label className="flex items-center gap-2 text-xs text-gray-500">
             <input type="checkbox" name="regenerate_draft_key" />

--- a/admin-pages/app/comic/series/page.tsx
+++ b/admin-pages/app/comic/series/page.tsx
@@ -1,5 +1,6 @@
 import { listComicSeries } from '@/lib/db_comic'
 import { createComicSeriesAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -42,9 +43,7 @@ export default async function ComicSeries({ searchParams }: { searchParams: Prom
             <input name="series_name" required className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm" />
           </div>
         </div>
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          追加
-        </button>
+        <SubmitButton pendingText="追加中...">追加</SubmitButton>
       </form>
     </div>
   )

--- a/admin-pages/app/comic/tags/page.tsx
+++ b/admin-pages/app/comic/tags/page.tsx
@@ -1,5 +1,6 @@
 import { listComicTags } from '@/lib/db_comic'
 import { createComicTagAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -42,9 +43,7 @@ export default async function ComicTags({ searchParams }: { searchParams: Promis
             <input name="tag_name" required className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm" />
           </div>
         </div>
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          追加
-        </button>
+        <SubmitButton pendingText="追加中...">追加</SubmitButton>
       </form>
     </div>
   )

--- a/admin-pages/app/illust/atelier-form.tsx
+++ b/admin-pages/app/illust/atelier-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react'
 import type { atelierRow, atelierTagRow } from 'api-types'
 import { createAtelierAction, updateAtelierAction, previewAtelierAction } from './actions'
+import { SubmitButton } from '@/components/submit-button'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -149,16 +150,10 @@ export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error
 
         <div className="space-y-2 border-t border-gray-100 pt-4">
           <div className="flex gap-3">
-            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-              保存
-            </button>
-            <button
-              type="submit"
-              formAction={previewFormAction}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-            >
+            <SubmitButton pendingText="保存中...">保存</SubmitButton>
+            <SubmitButton variant="secondary" formAction={previewFormAction} pendingText="プレビュー保存中...">
               プレビュー保存（D1には保存しない）
-            </button>
+            </SubmitButton>
           </div>
           <label className="flex items-center gap-2 text-xs text-gray-500">
             <input type="checkbox" name="regenerate_draft_key" />

--- a/admin-pages/app/illust/tags/page.tsx
+++ b/admin-pages/app/illust/tags/page.tsx
@@ -1,5 +1,6 @@
 import { listTags } from '@/lib/db'
 import { createTagAction } from '../actions'
+import { SubmitButton } from '@/components/submit-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -58,9 +59,7 @@ export default async function IllustTags({ searchParams }: { searchParams: Promi
             </datalist>
           </div>
         </div>
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          追加
-        </button>
+        <SubmitButton pendingText="追加中...">追加</SubmitButton>
       </form>
     </div>
   )

--- a/admin-pages/components/submit-button.tsx
+++ b/admin-pages/components/submit-button.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+
+type Props = {
+  children: React.ReactNode
+  variant?: 'primary' | 'secondary' | 'danger'
+  size?: 'md' | 'sm'
+  pendingText?: string
+  formAction?: string | ((formData: FormData) => void | Promise<void>)
+}
+
+const VARIANT_CLASS = {
+  primary: 'bg-gray-900 text-white hover:bg-gray-700',
+  secondary: 'border border-gray-300 hover:bg-gray-100',
+  danger: 'bg-red-700 text-white hover:bg-red-600',
+}
+
+const SIZE_CLASS = {
+  md: 'px-4 py-2',
+  sm: 'px-3 py-1.5',
+}
+
+// フォームの送信中は同一フォーム内の全送信ボタンを無効化し、二度押し（多重送信）を防ぐ
+export function SubmitButton({ children, variant = 'primary', size = 'md', pendingText = '処理中...', formAction }: Props) {
+  const { pending } = useFormStatus()
+  return (
+    <button
+      type="submit"
+      formAction={formAction}
+      disabled={pending}
+      aria-busy={pending}
+      className={`rounded-md text-sm ${SIZE_CLASS[size]} ${VARIANT_CLASS[variant]} disabled:cursor-not-allowed disabled:opacity-50`}
+    >
+      {pending ? pendingText : children}
+    </button>
+  )
+}


### PR DESCRIPTION
## 概要
#1133 の改修項目「保存や変更のボタンを押したときのアクションが小さいため画面遷移に時間がかかるとボタン二度押しなどの問題が起きそう」の対応。

- `useFormStatus` を使った共通コンポーネント `components/submit-button.tsx` を追加
- 送信中は同一フォーム内の送信ボタンをすべて無効化（disabled）し、ラベルを「保存中...」「パージ中...」等に変更
- 適用箇所: ブログ/マンガ/イラストの編集フォーム（保存・プレビュー）、固定ページ、カテゴリ管理（表示順保存・追加）、静的文言、タグ・シリーズ追加、キャッシュ管理（グループパージ・全パージ）

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)