### PR TITLE
feat(admin): パンくずリストを追加

### DIFF
--- a/admin-pages/app/layout.tsx
+++ b/admin-pages/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { Breadcrumbs } from '@/components/breadcrumbs'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -32,7 +33,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             </nav>
           </div>
         </header>
-        <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+        <main className="mx-auto max-w-5xl px-4 py-6">
+          <Breadcrumbs />
+          {children}
+        </main>
       </body>
     </html>
   )

--- a/admin-pages/components/breadcrumbs.tsx
+++ b/admin-pages/components/breadcrumbs.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const SEGMENT_LABELS: Record<string, string> = {
+  illust: 'イラスト',
+  comic: 'マンガ',
+  blog: 'ブログ',
+  cache: 'キャッシュ管理',
+  new: '新規作成',
+  edit: '編集',
+  tags: 'タグ管理',
+  series: 'シリーズ管理',
+  categories: 'カテゴリ管理',
+  info: '固定ページ',
+  static: '静的文言',
+}
+
+// 一覧ページとして遷移可能なパス。中間セグメントはここに含まれるときだけリンクにする
+// （/blog/{id} のようなページは存在しないため、コンテンツIDはリンクにしない）
+const LINKABLE_PATHS = new Set(['/illust', '/comic', '/blog', '/blog/info'])
+
+export function Breadcrumbs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/').filter(Boolean)
+  if (segments.length === 0) {
+    return null
+  }
+
+  const items = segments.map((segment, i) => {
+    const href = '/' + segments.slice(0, i + 1).join('/')
+    const label = SEGMENT_LABELS[segment]
+    const isLast = i === segments.length - 1
+    return { href, segment, label, isLast }
+  })
+
+  return (
+    <nav aria-label="パンくずリスト" className="mb-4 flex flex-wrap items-center gap-1 text-sm text-gray-500">
+      <Link href="/" className="hover:text-gray-900 hover:underline">
+        ホーム
+      </Link>
+      {items.map((item) => (
+        <span key={item.href} className="flex items-center gap-1">
+          <span aria-hidden="true">/</span>
+          {!item.isLast && LINKABLE_PATHS.has(item.href) ? (
+            <Link href={item.href} className="hover:text-gray-900 hover:underline">
+              {item.label ?? item.segment}
+            </Link>
+          ) : item.label ? (
+            <span className={item.isLast ? 'font-medium text-gray-900' : undefined}>{item.label}</span>
+          ) : (
+            // ラベル未定義のセグメントはコンテンツID（動的セグメント）
+            <span className="font-mono text-xs">{item.segment}</span>
+          )}
+        </span>
+      ))}
+    </nav>
+  )
+}


### PR DESCRIPTION
## 概要
#1133 の改修項目「パンくずリストがほしい」の対応。

- `components/breadcrumbs.tsx` を追加し、レイアウトの main 直下（全ページ共通）に表示
- URLセグメントベースで生成: `ホーム / ブログ / {記事ID} / 編集` のような表示
- 既知セグメントは日本語ラベル（イラスト・マンガ・ブログ・キャッシュ管理・新規作成・編集・タグ管理・シリーズ管理・カテゴリ管理・固定ページ・静的文言）
- 記事IDなどの動的セグメントは等幅フォントでそのまま表示（対応する単独ページがないためリンクにしない）
- 中間セグメントは遷移先ページが実在するもの（/illust, /comic, /blog, /blog/info）のみリンク化

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)