### PR TITLE
feat(admin): 記事編集画面にキャッシュ削除ボタンを追加

### DIFF
--- a/admin-pages/app/blog/[id]/edit/page.tsx
+++ b/admin-pages/app/blog/[id]/edit/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { getBlogContent, getBlogContentCategoryIDs, listBlogCategories } from '@/lib/db_blog'
 import { BlogForm } from '../../blog-form'
+import { purgeBlogContentCacheAction } from '../../actions'
+import { PurgeCacheButton } from '@/components/purge-cache-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,6 +25,12 @@ export default async function EditBlogContent({
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">ブログ記事編集: {article.title}</h1>
+      <PurgeCacheButton
+        action={purgeBlogContentCacheAction}
+        contentID={id}
+        label="この記事のキャッシュを削除"
+        description="一覧キャッシュと記事単体キャッシュを削除します。保存時は自動でパージされるため、表示の不整合時などに使用してください"
+      />
       <BlogForm
         mode="edit"
         article={article}

--- a/admin-pages/app/blog/actions.ts
+++ b/admin-pages/app/blog/actions.ts
@@ -20,7 +20,7 @@ import { purgeBlogContentCache, purgeBlogMetaCache } from '@/lib/cache'
 import { saveBlogContentDraft } from '@/lib/draft_blog'
 import { notifyBlogPublishToSNS } from '@/lib/sns'
 import { generateContentID } from '@/lib/id'
-import type { PreviewActionState } from '@/lib/form-state'
+import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/
@@ -115,6 +115,23 @@ export async function previewBlogContentAction(
   const draftKey = await saveBlogContentDraft(input)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/blog/${input.id}?draftKey=${draftKey}` }
+}
+
+// 編集画面からの手動キャッシュ削除。編集中の本文を失わないようページ遷移させない
+export async function purgeBlogContentCacheAction(
+  _prev: PurgeActionState,
+  formData: FormData
+): Promise<PurgeActionState> {
+  const id = text(formData, 'id')
+  if (id === '') {
+    return { error: 'IDが不正です' }
+  }
+  try {
+    await purgeBlogContentCache(id)
+    return { done: 'この記事のキャッシュを削除しました（一覧・記事単体）' }
+  } catch {
+    return { error: 'キャッシュ削除に失敗しました' }
+  }
 }
 
 // カテゴリ表示順の一括更新（order_{id} = 数値 のフォーム値を反映）

--- a/admin-pages/app/comic/[id]/edit/page.tsx
+++ b/admin-pages/app/comic/[id]/edit/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { getBandeDessinee, listComicTags, listComicSeries } from '@/lib/db_comic'
 import { ComicForm } from '../../comic-form'
+import { purgeBandeDessineeCacheAction } from '../../actions'
+import { PurgeCacheButton } from '@/components/purge-cache-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,6 +25,12 @@ export default async function EditComic({
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">マンガ編集: {comic.title_name}</h1>
+      <PurgeCacheButton
+        action={purgeBandeDessineeCacheAction}
+        contentID={id}
+        label="マンガのキャッシュを削除"
+        description="マンガのキャッシュは一覧・単体まとめて削除されます。保存時は自動でパージされるため、表示の不整合時などに使用してください"
+      />
       <ComicForm
         mode="edit"
         comic={comic}

--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -14,7 +14,7 @@ import {
 import { purgeBandeDessineeCache } from '@/lib/cache'
 import { saveBandeDessineeDraft } from '@/lib/draft_comic'
 import { generateContentID } from '@/lib/id'
-import type { PreviewActionState } from '@/lib/form-state'
+import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/
@@ -122,6 +122,19 @@ export async function previewBandeDessineeAction(
   const draftKey = await saveBandeDessineeDraft(input)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/comics/${input.id}?draftKey=${draftKey}` }
+}
+
+// 編集画面からの手動キャッシュ削除。マンガのキャッシュはプレフィックス単位（一覧・単体まとめて）で削除する
+export async function purgeBandeDessineeCacheAction(
+  _prev: PurgeActionState,
+  _formData: FormData
+): Promise<PurgeActionState> {
+  try {
+    await purgeBandeDessineeCache()
+    return { done: 'マンガのキャッシュを削除しました（一覧・単体すべて）' }
+  } catch {
+    return { error: 'キャッシュ削除に失敗しました' }
+  }
 }
 
 export async function createComicTagAction(formData: FormData): Promise<void> {

--- a/admin-pages/app/illust/[id]/edit/page.tsx
+++ b/admin-pages/app/illust/[id]/edit/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { getAtelier, getAtelierTagIDs, listTags } from '@/lib/db'
 import { AtelierForm } from '../../atelier-form'
+import { purgeAtelierCacheAction } from '../../actions'
+import { PurgeCacheButton } from '@/components/purge-cache-button'
 
 export const dynamic = 'force-dynamic'
 
@@ -23,6 +25,12 @@ export default async function EditIllust({
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">イラスト編集: {atelier.title}</h1>
+      <PurgeCacheButton
+        action={purgeAtelierCacheAction}
+        contentID={id}
+        label="イラストのキャッシュを削除"
+        description="イラストのキャッシュは一覧・単体まとめて削除されます。保存時は自動でパージされるため、表示の不整合時などに使用してください"
+      />
       <AtelierForm
         mode="edit"
         atelier={atelier}

--- a/admin-pages/app/illust/actions.ts
+++ b/admin-pages/app/illust/actions.ts
@@ -7,7 +7,7 @@ import { createAtelier, updateAtelier, getAtelier, createTag, type AtelierInput 
 import { purgeAtelierCache } from '@/lib/cache'
 import { saveAtelierDraft } from '@/lib/draft'
 import { generateContentID } from '@/lib/id'
-import type { PreviewActionState } from '@/lib/form-state'
+import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
 const VALID_POSITION = ['center', 'top', 'bottom', 'left', 'right']
@@ -85,6 +85,16 @@ export async function previewAtelierAction(
   const draftKey = await saveAtelierDraft(input)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/illust/detail/${input.id}?draftKey=${draftKey}` }
+}
+
+// 編集画面からの手動キャッシュ削除。イラストのキャッシュはプレフィックス単位（一覧・単体まとめて）で削除する
+export async function purgeAtelierCacheAction(_prev: PurgeActionState, _formData: FormData): Promise<PurgeActionState> {
+  try {
+    await purgeAtelierCache()
+    return { done: 'イラストのキャッシュを削除しました（一覧・単体すべて）' }
+  } catch {
+    return { error: 'キャッシュ削除に失敗しました' }
+  }
 }
 
 export async function createTagAction(formData: FormData): Promise<void> {

--- a/admin-pages/components/purge-cache-button.tsx
+++ b/admin-pages/components/purge-cache-button.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useActionState } from 'react'
+import type { PurgeActionState } from '@/lib/form-state'
+
+type Props = {
+  // サーバーアクション（サービスごとに異なるパージ処理を渡す）
+  action: (prev: PurgeActionState, formData: FormData) => Promise<PurgeActionState>
+  contentID: string
+  label: string
+  description?: string
+}
+
+// 編集画面用のキャッシュ削除ボタン。編集中の本文を失わないようページ遷移させず結果を表示する
+export function PurgeCacheButton({ action, contentID, label, description }: Props) {
+  const [state, formAction, pending] = useActionState(action, {})
+
+  return (
+    <form action={formAction} className="flex flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-white p-3">
+      <input type="hidden" name="id" value={contentID} />
+      <button
+        type="submit"
+        disabled={pending}
+        className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {pending ? 'パージ中...' : label}
+      </button>
+      {state.done && <span className="text-sm text-green-700">{state.done}</span>}
+      {state.error && <span className="text-sm text-red-700">{state.error}</span>}
+      {description && <span className="text-xs text-gray-400">{description}</span>}
+    </form>
+  )
+}

--- a/admin-pages/lib/form-state.ts
+++ b/admin-pages/lib/form-state.ts
@@ -4,3 +4,10 @@ export type PreviewActionState = {
   previewURL?: string
   error?: string
 }
+
+// useActionState で受け渡すキャッシュパージアクションの結果
+// 編集画面上のボタンのためページ遷移させない（遷移すると編集中の本文が消えるため）
+export type PurgeActionState = {
+  done?: string
+  error?: string
+}


### PR DESCRIPTION
## 概要
#1133 の改修項目「記事編集画面から対象記事のcacheを削除するボタンを追加」の対応。

- 共通コンポーネント `components/purge-cache-button.tsx` を追加し、ブログ・マンガ・イラストの編集画面（タイトル直下）に配置
- **ブログ**: 対象記事の単体キャッシュ（`content_{id}`）+ 一覧キャッシュ（`contents_*`）を削除
- **イラスト・マンガ**: キャッシュキーがプレフィックス単位（`atelier_*` / `bande_dessinee_*`）のため一覧・単体まとめて削除
- `useActionState` でページ遷移なしに結果を表示（編集中の本文が消えない）
- 保存時の自動パージがあるため、位置づけは表示不整合時などの手動リカバリ用（説明文も表示）

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)