### PR TITLE
feat(admin): 保存後に一覧へ戻らず編集画面に留まる

### DIFF
--- a/admin-pages/app/blog/[id]/edit/page.tsx
+++ b/admin-pages/app/blog/[id]/edit/page.tsx
@@ -9,10 +9,10 @@ export default async function EditBlogContent({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ error?: string }>
+  searchParams: Promise<{ error?: string; saved?: string }>
 }) {
   const { id } = await params
-  const { error } = await searchParams
+  const { error, saved } = await searchParams
 
   const article = await getBlogContent(id)
   if (!article) {
@@ -29,6 +29,7 @@ export default async function EditBlogContent({
         selectedCategoryIDs={selectedCategoryIDs}
         allCategories={allCategories}
         error={error}
+        saved={saved === '1'}
       />
     </div>
   )

--- a/admin-pages/app/blog/actions.ts
+++ b/admin-pages/app/blog/actions.ts
@@ -81,7 +81,8 @@ export async function createBlogContentAction(formData: FormData): Promise<void>
   await notifyBlogPublishToSNS({ input, type: 'new' })
 
   revalidatePath('/blog')
-  redirect('/blog')
+  // 保存後は一覧へ戻らず、作成した記事の編集画面へ遷移する（連続編集のため）
+  redirect(`/blog/${input.id}/edit?saved=1`)
 }
 
 export async function updateBlogContentAction(formData: FormData): Promise<void> {
@@ -99,7 +100,8 @@ export async function updateBlogContentAction(formData: FormData): Promise<void>
   await notifyBlogPublishToSNS({ input, type: 'edit', oldStatus })
 
   revalidatePath('/blog')
-  redirect('/blog')
+  // 保存後は一覧へ戻らず、編集画面に留まる
+  redirect(`/blog/${input.id}/edit?saved=1`)
 }
 
 // プレビューはページ遷移させず結果を useActionState で返す（遷移すると編集中の本文が消えるため）
@@ -187,7 +189,8 @@ export async function createBlogInfoAction(formData: FormData): Promise<void> {
   await purgeBlogMetaCache('info')
 
   revalidatePath('/blog/info')
-  redirect('/blog/info')
+  // 保存後は一覧へ戻らず、作成したページの編集画面へ遷移する
+  redirect(`/blog/info/${input.id}/edit?saved=1`)
 }
 
 export async function updateBlogInfoAction(formData: FormData): Promise<void> {
@@ -200,7 +203,8 @@ export async function updateBlogInfoAction(formData: FormData): Promise<void> {
   await purgeBlogMetaCache('info')
 
   revalidatePath('/blog/info')
-  redirect('/blog/info')
+  // 保存後は一覧へ戻らず、編集画面に留まる
+  redirect(`/blog/info/${input.id}/edit?saved=1`)
 }
 
 export async function updateBlogStaticAction(formData: FormData): Promise<void> {

--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -10,9 +10,10 @@ type Props = {
   selectedCategoryIDs?: string[]
   allCategories: blogCategoryRow[]
   error?: string
+  saved?: boolean
 }
 
-export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategories, error }: Props) {
+export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategories, error, saved }: Props) {
   const action = mode === 'new' ? createBlogContentAction : updateBlogContentAction
   // プレビューはページ遷移させず結果だけ受け取る（遷移すると編集中の本文が消えるため）
   const [preview, previewFormAction] = useActionState(previewBlogContentAction, {})
@@ -20,6 +21,7 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
 
   return (
     <div className="space-y-4">
+      {saved && <p className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">保存しました</p>}
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
       {preview.error && (
         <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{preview.error}</p>

--- a/admin-pages/app/blog/info/[id]/edit/page.tsx
+++ b/admin-pages/app/blog/info/[id]/edit/page.tsx
@@ -9,10 +9,10 @@ export default async function EditBlogInfo({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ error?: string }>
+  searchParams: Promise<{ error?: string; saved?: string }>
 }) {
   const { id } = await params
-  const { error } = await searchParams
+  const { error, saved } = await searchParams
 
   const info = await getBlogInfo(id)
   if (!info) {
@@ -22,7 +22,7 @@ export default async function EditBlogInfo({
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">固定ページ編集: {info.page_pathname}</h1>
-      <InfoForm mode="edit" info={info} error={error} />
+      <InfoForm mode="edit" info={info} error={error} saved={saved === '1'} />
     </div>
   )
 }

--- a/admin-pages/app/blog/info/info-form.tsx
+++ b/admin-pages/app/blog/info/info-form.tsx
@@ -5,14 +5,16 @@ type Props = {
   mode: 'new' | 'edit'
   info?: blogInfoRow
   error?: string
+  saved?: boolean
 }
 
-export function InfoForm({ mode, info, error }: Props) {
+export function InfoForm({ mode, info, error, saved }: Props) {
   const action = mode === 'new' ? createBlogInfoAction : updateBlogInfoAction
   const inputClass = 'mt-1 w-full rounded-md border border-gray-300 p-2 text-sm'
 
   return (
     <div className="space-y-4">
+      {saved && <p className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">保存しました</p>}
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
 
       <form action={action} className="space-y-4 rounded-lg border border-gray-200 bg-white p-4">

--- a/admin-pages/app/comic/[id]/edit/page.tsx
+++ b/admin-pages/app/comic/[id]/edit/page.tsx
@@ -9,10 +9,10 @@ export default async function EditComic({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ error?: string }>
+  searchParams: Promise<{ error?: string; saved?: string }>
 }) {
   const { id } = await params
-  const { error } = await searchParams
+  const { error, saved } = await searchParams
 
   const comic = await getBandeDessinee(id)
   if (!comic) {
@@ -29,6 +29,7 @@ export default async function EditComic({
         allTags={allTags}
         allSeries={allSeries}
         error={error}
+        saved={saved === '1'}
       />
     </div>
   )

--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -93,7 +93,8 @@ export async function createBandeDessineeAction(formData: FormData): Promise<voi
   await purgeBandeDessineeCache()
 
   revalidatePath('/comic')
-  redirect('/comic')
+  // 保存後は一覧へ戻らず、作成したマンガの編集画面へ遷移する（連続編集のため）
+  redirect(`/comic/${input.id}/edit?saved=1`)
 }
 
 export async function updateBandeDessineeAction(formData: FormData): Promise<void> {
@@ -106,7 +107,8 @@ export async function updateBandeDessineeAction(formData: FormData): Promise<voi
   await purgeBandeDessineeCache()
 
   revalidatePath('/comic')
-  redirect('/comic')
+  // 保存後は一覧へ戻らず、編集画面に留まる
+  redirect(`/comic/${input.id}/edit?saved=1`)
 }
 
 // プレビューはページ遷移させず結果を useActionState で返す（遷移すると編集中の本文が消えるため）

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -10,6 +10,7 @@ type Props = {
   allTags: bandeDessineeTagRow[]
   allSeries: bandeDessineeSeriesRow[]
   error?: string
+  saved?: boolean
 }
 
 // ISO 8601 UTC の日時を date input 用の JST 日付（YYYY-MM-DD）に変換する
@@ -19,7 +20,7 @@ function toJSTDateValue(iso: string | null | undefined): string {
   return jst.toISOString().slice(0, 10)
 }
 
-export function ComicForm({ mode, comic, allTags, allSeries, error }: Props) {
+export function ComicForm({ mode, comic, allTags, allSeries, error, saved }: Props) {
   const action = mode === 'new' ? createBandeDessineeAction : updateBandeDessineeAction
   // プレビューはページ遷移させず結果だけ受け取る（遷移すると編集中の本文が消えるため）
   const [preview, previewFormAction] = useActionState(previewBandeDessineeAction, {})
@@ -28,6 +29,7 @@ export function ComicForm({ mode, comic, allTags, allSeries, error }: Props) {
 
   return (
     <div className="space-y-4">
+      {saved && <p className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">保存しました</p>}
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
       {preview.error && (
         <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{preview.error}</p>

--- a/admin-pages/app/illust/[id]/edit/page.tsx
+++ b/admin-pages/app/illust/[id]/edit/page.tsx
@@ -9,10 +9,10 @@ export default async function EditIllust({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ error?: string }>
+  searchParams: Promise<{ error?: string; saved?: string }>
 }) {
   const { id } = await params
-  const { error } = await searchParams
+  const { error, saved } = await searchParams
 
   const atelier = await getAtelier(id)
   if (!atelier) {
@@ -29,6 +29,7 @@ export default async function EditIllust({
         selectedTagIDs={selectedTagIDs}
         allTags={allTags}
         error={error}
+        saved={saved === '1'}
       />
     </div>
   )

--- a/admin-pages/app/illust/actions.ts
+++ b/admin-pages/app/illust/actions.ts
@@ -55,7 +55,8 @@ export async function createAtelierAction(formData: FormData): Promise<void> {
   await purgeAtelierCache()
 
   revalidatePath('/illust')
-  redirect('/illust')
+  // 保存後は一覧へ戻らず、作成したイラストの編集画面へ遷移する（連続編集のため）
+  redirect(`/illust/${input.id}/edit?saved=1`)
 }
 
 export async function updateAtelierAction(formData: FormData): Promise<void> {
@@ -68,7 +69,8 @@ export async function updateAtelierAction(formData: FormData): Promise<void> {
   await purgeAtelierCache()
 
   revalidatePath('/illust')
-  redirect('/illust')
+  // 保存後は一覧へ戻らず、編集画面に留まる
+  redirect(`/illust/${input.id}/edit?saved=1`)
 }
 
 // 編集中の内容をKVに保存し、pages本体のプレビューURLを返す（D1には書き込まない）

--- a/admin-pages/app/illust/atelier-form.tsx
+++ b/admin-pages/app/illust/atelier-form.tsx
@@ -10,17 +10,19 @@ type Props = {
   selectedTagIDs?: string[]
   allTags: atelierTagRow[]
   error?: string
+  saved?: boolean
 }
 
 const positions = ['center', 'top', 'bottom', 'left', 'right']
 
-export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error }: Props) {
+export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error, saved }: Props) {
   const action = mode === 'new' ? createAtelierAction : updateAtelierAction
   // プレビューはページ遷移させず結果だけ受け取る（遷移すると編集中の本文が消えるため）
   const [preview, previewFormAction] = useActionState(previewAtelierAction, {})
 
   return (
     <div className="space-y-4">
+      {saved && <p className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">保存しました</p>}
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
       {preview.error && (
         <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{preview.error}</p>


### PR DESCRIPTION
## 概要
#1133 の改修項目「コンテンツ編集画面で保存後に一覧ページに移動するのをやめたい」の対応。

- ブログ記事・マンガ・イラスト・固定ページの保存アクションのリダイレクト先を一覧から **対象コンテンツの編集画面**（`?saved=1` 付き）に変更
  - 更新時: そのまま編集画面に留まる（D1保存後の内容が再読み込みされる）
  - 新規作成時: 作成した記事の編集画面に遷移（そのまま続けて編集できる）
- 各フォームに「保存しました」の成功バナーを追加
- バリデーションエラー時の挙動（`?error=` 付きリダイレクト）は従来どおり
- カテゴリ・タグ・シリーズ・静的文言は元々同一ページ内で完結しているため変更なし

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)