### PR TITLE
feat(admin): ブログ編集画面からカテゴリーを追加できるように

### DIFF
--- a/admin-pages/app/blog/actions.ts
+++ b/admin-pages/app/blog/actions.ts
@@ -8,6 +8,7 @@ import {
   updateBlogContent,
   getBlogContent,
   createBlogCategory,
+  listBlogCategories,
   updateBlogCategoryOrders,
   createBlogInfo,
   updateBlogInfo,
@@ -21,7 +22,7 @@ import { saveBlogContentDraft } from '@/lib/draft_blog'
 import { notifyBlogPublishToSNS } from '@/lib/sns'
 import { generateContentID } from '@/lib/id'
 import { parseContentFormat } from '@/lib/content-format'
-import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
+import type { PreviewActionState, PurgeActionState, AddCategoryState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/
@@ -159,6 +160,30 @@ export async function updateBlogCategoryOrderAction(formData: FormData): Promise
 
   revalidatePath('/blog/categories')
   redirect('/blog/categories')
+}
+
+// 記事編集画面からのカテゴリ追加。編集中の本文を失わないようページ遷移させず、
+// 追加したカテゴリを累積して返す（フォーム側でチェックボックスに反映する）
+export async function addBlogCategoryInlineAction(
+  prev: AddCategoryState,
+  formData: FormData
+): Promise<AddCategoryState> {
+  const name = text(formData, 'new_category_name')
+  if (name === '') {
+    return { ...prev, error: 'カテゴリ名は必須です' }
+  }
+
+  const existing = await listBlogCategories()
+  if (existing.some((c) => c.name === name)) {
+    return { ...prev, error: `カテゴリ '${name}' は既に存在します` }
+  }
+
+  const id = generateContentID()
+  await createBlogCategory({ id, name })
+  await purgeBlogMetaCache('tags')
+
+  revalidatePath('/blog/categories')
+  return { categories: [...prev.categories, { id, name }] }
 }
 
 export async function createBlogCategoryAction(formData: FormData): Promise<void> {

--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -2,7 +2,12 @@
 
 import { useActionState } from 'react'
 import type { blogContentRow, blogCategoryRow } from 'api-types'
-import { createBlogContentAction, updateBlogContentAction, previewBlogContentAction } from './actions'
+import {
+  createBlogContentAction,
+  updateBlogContentAction,
+  previewBlogContentAction,
+  addBlogCategoryInlineAction,
+} from './actions'
 import { SubmitButton } from '@/components/submit-button'
 
 type Props = {
@@ -18,6 +23,11 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
   const action = mode === 'new' ? createBlogContentAction : updateBlogContentAction
   // プレビューはページ遷移させず結果だけ受け取る（遷移すると編集中の本文が消えるため）
   const [preview, previewFormAction] = useActionState(previewBlogContentAction, {})
+  // カテゴリのインライン追加もページ遷移させない。追加分は累積されチェック済みで表示する
+  const [added, addCategoryFormAction, addingCategory] = useActionState(addBlogCategoryInlineAction, {
+    categories: [],
+  })
+  const addedCategories = added.categories.filter((c) => !allCategories.some((a) => a.id === c.id))
   const inputClass = 'mt-1 w-full rounded-md border border-gray-300 p-2 text-sm'
 
   return (
@@ -93,9 +103,38 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
                 {c.name}
               </label>
             ))}
+            {addedCategories.map((c) => (
+              <label key={c.id} className="flex items-center gap-1 text-sm">
+                {/* インライン追加した直後のカテゴリはチェック済みで表示する */}
+                <input type="checkbox" name="category_ids" value={c.id} defaultChecked />
+                {c.name} <span className="text-xs text-green-600">（追加済み）</span>
+              </label>
+            ))}
+          </div>
+          <div className="mt-2 flex items-center gap-2">
+            {/* form属性で本文フォームの外にある追加専用フォームに紐づける（フォームのネスト回避） */}
+            <input
+              form="add-category-form"
+              name="new_category_name"
+              placeholder="新しいカテゴリ名"
+              className="w-64 rounded-md border border-gray-300 p-1.5 text-sm"
+            />
+            <button
+              type="submit"
+              form="add-category-form"
+              disabled={addingCategory}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {addingCategory ? '追加中...' : 'カテゴリ追加'}
+            </button>
+            {added.error && <span className="text-xs text-red-700">{added.error}</span>}
           </div>
           <p className="mt-1 text-xs text-gray-400">
-            追加は <a href="/blog/categories" className="underline">カテゴリ管理</a> から
+            IDの指定や表示順の変更は{' '}
+            <a href="/blog/categories" target="_blank" rel="noopener noreferrer" className="underline">
+              カテゴリ管理
+            </a>{' '}
+            から（新しいタブで開きます）
           </p>
         </div>
 
@@ -156,6 +195,9 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
           </label>
         </div>
       </form>
+
+      {/* カテゴリ追加用フォームの実体。本文フォームとネストできないため外に置き、form属性で参照する */}
+      <form id="add-category-form" action={addCategoryFormAction} />
     </div>
   )
 }

--- a/admin-pages/lib/form-state.ts
+++ b/admin-pages/lib/form-state.ts
@@ -11,3 +11,10 @@ export type PurgeActionState = {
   done?: string
   error?: string
 }
+
+// ブログ編集画面からのカテゴリ追加（インライン）の結果
+// 追加済みカテゴリを累積して返し、フォーム側でチェックボックスに反映する（ページ遷移させない）
+export type AddCategoryState = {
+  categories: { id: string; name: string }[]
+  error?: string
+}


### PR DESCRIPTION
## 概要
#1133 の改修項目「ブログ記事編集画面からカテゴリー編集をしたい」の対応。

- ブログ編集フォームのカテゴリ欄に「新しいカテゴリ名」入力＋「カテゴリ追加」ボタンを追加
- **編集中の本文が消えないよう、ページ遷移なし**で追加（`useActionState`）
  - フォームのネストを避けるため `form` 属性で本文フォーム外の追加専用フォームに紐づけ
- 追加したカテゴリは即座にチェック済みのチェックボックスとして表示され、そのまま保存すれば記事に紐づく
- 追加は末尾（sort_order最大+1）・ID自動生成。IDの指定や表示順変更は従来のカテゴリ管理ページ（リンクを新しいタブで開くように変更）
- カテゴリ名の重複チェックあり。追加時は tags キャッシュもパージ

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)