### PR TITLE
feat(admin): プレビューのdraftKey再生成を任意化（既定は維持）

### DIFF
--- a/admin-pages/app/blog/actions.ts
+++ b/admin-pages/app/blog/actions.ts
@@ -112,7 +112,9 @@ export async function previewBlogContentAction(
     return { error }
   }
 
-  const draftKey = await saveBlogContentDraft(input)
+  // draftKeyは既定で維持し、チェックされたときのみ再生成する（プレビューURLの変更を任意にする）
+  const regenerateKey = formData.get('regenerate_draft_key') === 'on'
+  const draftKey = await saveBlogContentDraft(input, regenerateKey)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/blog/${input.id}?draftKey=${draftKey}` }
 }

--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -130,17 +130,23 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
           </p>
         </div>
 
-        <div className="flex gap-3 border-t border-gray-100 pt-4">
-          <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-            保存
-          </button>
-          <button
-            type="submit"
-            formAction={previewFormAction}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-          >
-            プレビュー保存（D1には保存しない）
-          </button>
+        <div className="space-y-2 border-t border-gray-100 pt-4">
+          <div className="flex gap-3">
+            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
+              保存
+            </button>
+            <button
+              type="submit"
+              formAction={previewFormAction}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
+            >
+              プレビュー保存（D1には保存しない）
+            </button>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-gray-500">
+            <input type="checkbox" name="regenerate_draft_key" />
+            プレビューURL（draftKey）を再生成する（未チェックなら既存のプレビューURLのまま内容だけ更新されます）
+          </label>
         </div>
       </form>
     </div>

--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -119,7 +119,9 @@ export async function previewBandeDessineeAction(
     return { error }
   }
 
-  const draftKey = await saveBandeDessineeDraft(input)
+  // draftKeyは既定で維持し、チェックされたときのみ再生成する（プレビューURLの変更を任意にする）
+  const regenerateKey = formData.get('regenerate_draft_key') === 'on'
+  const draftKey = await saveBandeDessineeDraft(input, regenerateKey)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/comics/${input.id}?draftKey=${draftKey}` }
 }

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -195,17 +195,23 @@ export function ComicForm({ mode, comic, allTags, allSeries, error }: Props) {
           />
         </div>
 
-        <div className="flex gap-3 border-t border-gray-100 pt-4">
-          <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-            保存
-          </button>
-          <button
-            type="submit"
-            formAction={previewFormAction}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-          >
-            プレビュー保存（D1には保存しない）
-          </button>
+        <div className="space-y-2 border-t border-gray-100 pt-4">
+          <div className="flex gap-3">
+            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
+              保存
+            </button>
+            <button
+              type="submit"
+              formAction={previewFormAction}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
+            >
+              プレビュー保存（D1には保存しない）
+            </button>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-gray-500">
+            <input type="checkbox" name="regenerate_draft_key" />
+            プレビューURL（draftKey）を再生成する（未チェックなら既存のプレビューURLのまま内容だけ更新されます）
+          </label>
         </div>
       </form>
     </div>

--- a/admin-pages/app/illust/actions.ts
+++ b/admin-pages/app/illust/actions.ts
@@ -82,7 +82,9 @@ export async function previewAtelierAction(
     return { error }
   }
 
-  const draftKey = await saveAtelierDraft(input)
+  // draftKeyは既定で維持し、チェックされたときのみ再生成する（プレビューURLの変更を任意にする）
+  const regenerateKey = formData.get('regenerate_draft_key') === 'on'
+  const draftKey = await saveAtelierDraft(input, regenerateKey)
   const { env } = await getCloudflareContext({ async: true })
   return { previewURL: `${env.PAGES_HOST}/illust/detail/${input.id}?draftKey=${draftKey}` }
 }

--- a/admin-pages/app/illust/atelier-form.tsx
+++ b/admin-pages/app/illust/atelier-form.tsx
@@ -134,17 +134,23 @@ export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error
           </select>
         </div>
 
-        <div className="flex gap-3 border-t border-gray-100 pt-4">
-          <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-            保存
-          </button>
-          <button
-            type="submit"
-            formAction={previewFormAction}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
-          >
-            プレビュー保存（D1には保存しない）
-          </button>
+        <div className="space-y-2 border-t border-gray-100 pt-4">
+          <div className="flex gap-3">
+            <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
+              保存
+            </button>
+            <button
+              type="submit"
+              formAction={previewFormAction}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm hover:bg-gray-100"
+            >
+              プレビュー保存（D1には保存しない）
+            </button>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-gray-500">
+            <input type="checkbox" name="regenerate_draft_key" />
+            プレビューURL（draftKey）を再生成する（未チェックなら既存のプレビューURLのまま内容だけ更新されます）
+          </label>
         </div>
       </form>
     </div>

--- a/admin-pages/lib/draft.ts
+++ b/admin-pages/lib/draft.ts
@@ -12,10 +12,19 @@ import type { AtelierInput } from './db'
 // プレビューURLの有効期間（KVのTTL）。失効後は再度プレビュー保存すればよい
 const DRAFT_TTL_SECONDS = 3 * 24 * 60 * 60
 
-export async function saveAtelierDraft(input: AtelierInput): Promise<string> {
+export async function saveAtelierDraft(input: AtelierInput, regenerateKey = false): Promise<string> {
   const { env } = await getCloudflareContext({ async: true })
   const now = new Date().toISOString()
   const current = await getAtelier(input.id)
+  const kvKey = `draft_atelier_${input.id}`
+
+  // 既存ドラフトのdraftKeyを維持する（共有済みのプレビューURLを変えないため）。再生成指定時のみ新しいキーにする
+  let draftKey: string | null = null
+  if (!regenerateKey) {
+    const existing = await env.CMS_DRAFT.get<atelierDraftRecord>(kvKey, 'json')
+    draftKey = existing?.draftKey ?? null
+  }
+  draftKey ??= generateDraftKey()
 
   const row: atelierRow = {
     id: input.id,
@@ -47,10 +56,9 @@ export async function saveAtelierDraft(input: AtelierInput): Promise<string> {
       revisedAt: t.revised_at ?? t.updated_at,
     }))
 
-  const draftKey = generateDraftKey()
   const record: atelierDraftRecord = { draftKey, row, tags }
 
-  await env.CMS_DRAFT.put(`draft_atelier_${input.id}`, JSON.stringify(record), {
+  await env.CMS_DRAFT.put(kvKey, JSON.stringify(record), {
     expirationTtl: DRAFT_TTL_SECONDS,
   })
 

--- a/admin-pages/lib/draft_blog.ts
+++ b/admin-pages/lib/draft_blog.ts
@@ -9,10 +9,19 @@ import type { BlogContentInput } from './db_blog'
 
 const DRAFT_TTL_SECONDS = 3 * 24 * 60 * 60
 
-export async function saveBlogContentDraft(input: BlogContentInput): Promise<string> {
+export async function saveBlogContentDraft(input: BlogContentInput, regenerateKey = false): Promise<string> {
   const { env } = await getCloudflareContext({ async: true })
   const now = new Date().toISOString()
   const current = await getBlogContent(input.id)
+  const kvKey = `draft_blog_${input.id}`
+
+  // 既存ドラフトのdraftKeyを維持する（共有済みのプレビューURLを変えないため）。再生成指定時のみ新しいキーにする
+  let draftKey: string | null = null
+  if (!regenerateKey) {
+    const existing = await env.CMS_DRAFT.get<blogContentDraftRecord>(kvKey, 'json')
+    draftKey = existing?.draftKey ?? null
+  }
+  draftKey ??= generateDraftKey()
 
   const row: blogContentRow = {
     id: input.id,
@@ -35,10 +44,9 @@ export async function saveBlogContentDraft(input: BlogContentInput): Promise<str
     .map((id) => allCategories.find((c) => c.id === id))
     .filter((c) => c !== undefined)
 
-  const draftKey = generateDraftKey()
   const record: blogContentDraftRecord = { draftKey, row, categories }
 
-  await env.CMS_DRAFT.put(`draft_blog_${input.id}`, JSON.stringify(record), {
+  await env.CMS_DRAFT.put(kvKey, JSON.stringify(record), {
     expirationTtl: DRAFT_TTL_SECONDS,
   })
 

--- a/admin-pages/lib/draft_comic.ts
+++ b/admin-pages/lib/draft_comic.ts
@@ -9,10 +9,19 @@ import type { BandeDessineeInput } from './db_comic'
 
 const DRAFT_TTL_SECONDS = 3 * 24 * 60 * 60
 
-export async function saveBandeDessineeDraft(input: BandeDessineeInput): Promise<string> {
+export async function saveBandeDessineeDraft(input: BandeDessineeInput, regenerateKey = false): Promise<string> {
   const { env } = await getCloudflareContext({ async: true })
   const now = new Date().toISOString()
   const current = await getBandeDessinee(input.id)
+  const kvKey = `draft_bande_dessinee_${input.id}`
+
+  // 既存ドラフトのdraftKeyを維持する（共有済みのプレビューURLを変えないため）。再生成指定時のみ新しいキーにする
+  let draftKey: string | null = null
+  if (!regenerateKey) {
+    const existing = await env.CMS_DRAFT.get<bandeDessineeDraftRecord>(kvKey, 'json')
+    draftKey = existing?.draftKey ?? null
+  }
+  draftKey ??= generateDraftKey()
 
   const row: bandeDessineeRow = {
     id: input.id,
@@ -47,7 +56,6 @@ export async function saveBandeDessineeDraft(input: BandeDessineeInput): Promise
   }
   const series = input.series_id ? ((await listComicSeries()).find((s) => s.id === input.series_id) ?? null) : null
 
-  const draftKey = generateDraftKey()
   const record: bandeDessineeDraftRecord = {
     draftKey,
     row,
@@ -55,7 +63,7 @@ export async function saveBandeDessineeDraft(input: BandeDessineeInput): Promise
     series: series ? { id: series.id, series_name: series.series_name } : null,
   }
 
-  await env.CMS_DRAFT.put(`draft_bande_dessinee_${input.id}`, JSON.stringify(record), {
+  await env.CMS_DRAFT.put(kvKey, JSON.stringify(record), {
     expirationTtl: DRAFT_TTL_SECONDS,
   })
 


### PR DESCRIPTION
## 概要
#1133 の改修項目「プレビュー保存時にdraft keyが毎回変更されるが、変更を任意にしたい」の対応。

- プレビュー保存時、KV（CMS_DRAFT）に既存ドラフトがあれば **そのdraftKeyを再利用**（既定動作）
  - 共有済みのプレビューURLがそのまま最新内容に更新される
- プレビューボタンの下に「プレビューURL（draftKey）を再生成する」チェックボックスを追加（ブログ・マンガ・イラスト共通）
  - チェック時のみ新しいdraftKeyを発行（旧URLは無効になる）
- KVのTTL（3日）は保存のたびに延長される挙動は従来どおり

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)