### PR TITLE
feat(admin): カテゴリ表示順をD&Dで並べ替え

### DIFF
--- a/admin-pages/app/blog/categories/category-order-list.tsx
+++ b/admin-pages/app/blog/categories/category-order-list.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import type { blogCategoryRow } from 'api-types'
+import { updateBlogCategoryOrderAction } from '../actions'
+
+// カテゴリの表示順をドラッグ&ドロップ（と↑↓ボタン）で並べ替えるリスト。
+// 並び順は hidden input（order_{id} = index）として送信し、既存のアクションで一括保存する
+export function CategoryOrderList({ categories }: { categories: blogCategoryRow[] }) {
+  const [items, setItems] = useState(categories.map((c) => ({ id: c.id, name: c.name })))
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+
+  const move = (from: number, to: number) => {
+    if (to < 0 || to >= items.length || from === to) {
+      return
+    }
+    setItems((prev) => {
+      const next = [...prev]
+      const [moved] = next.splice(from, 1)
+      next.splice(to, 0, moved)
+      return next
+    })
+  }
+
+  return (
+    <form action={updateBlogCategoryOrderAction} className="space-y-3">
+      <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+        {items.map((item, i) => (
+          <li
+            key={item.id}
+            draggable
+            onDragStart={() => setDragIndex(i)}
+            onDragOver={(e) => {
+              e.preventDefault()
+              // ドラッグ中の行が別の行に重なったら、その位置へ移動してプレビューする
+              if (dragIndex !== null && dragIndex !== i) {
+                move(dragIndex, i)
+                setDragIndex(i)
+              }
+            }}
+            onDrop={(e) => e.preventDefault()}
+            onDragEnd={() => setDragIndex(null)}
+            className={`flex cursor-grab items-center gap-3 p-2 text-sm ${dragIndex === i ? 'bg-blue-50' : ''}`}
+          >
+            <input type="hidden" name={`order_${item.id}`} value={i} />
+            <span aria-hidden="true" className="select-none text-gray-400">
+              ⠿
+            </span>
+            <span className="w-6 text-right text-xs text-gray-400">{i + 1}</span>
+            <span className="flex-1">{item.name}</span>
+            <span className="font-mono text-xs text-gray-400">{item.id}</span>
+            <span className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => move(i, i - 1)}
+                disabled={i === 0}
+                aria-label="上へ移動"
+                className="rounded border border-gray-300 px-2 py-0.5 text-xs hover:bg-gray-100 disabled:opacity-30"
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={() => move(i, i + 1)}
+                disabled={i === items.length - 1}
+                aria-label="下へ移動"
+                className="rounded border border-gray-300 px-2 py-0.5 text-xs hover:bg-gray-100 disabled:opacity-30"
+              >
+                ↓
+              </button>
+            </span>
+          </li>
+        ))}
+        {items.length === 0 && <li className="p-4 text-center text-sm text-gray-400">カテゴリがありません</li>}
+      </ul>
+      <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
+        この並び順で保存
+      </button>
+      <p className="text-xs text-gray-400">ドラッグ&ドロップまたは↑↓ボタンで並べ替え、保存で確定します</p>
+    </form>
+  )
+}

--- a/admin-pages/app/blog/categories/page.tsx
+++ b/admin-pages/app/blog/categories/page.tsx
@@ -1,5 +1,6 @@
 import { listBlogCategories } from '@/lib/db_blog'
-import { createBlogCategoryAction, updateBlogCategoryOrderAction } from '../actions'
+import { createBlogCategoryAction } from '../actions'
+import { CategoryOrderList } from './category-order-list'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,36 +14,7 @@ export default async function BlogCategories({ searchParams }: { searchParams: P
 
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
 
-      <form action={updateBlogCategoryOrderAction} className="space-y-3">
-        <table className="w-full border-collapse bg-white text-sm">
-          <thead>
-            <tr className="border-b border-gray-200 text-left text-gray-500">
-              <th className="p-2">表示順</th>
-              <th className="p-2">ID</th>
-              <th className="p-2">カテゴリ名</th>
-            </tr>
-          </thead>
-          <tbody>
-            {categories.map((c) => (
-              <tr key={c.id} className="border-b border-gray-100">
-                <td className="p-2">
-                  <input
-                    type="number"
-                    name={`order_${c.id}`}
-                    defaultValue={c.sort_order}
-                    className="w-20 rounded-md border border-gray-300 p-1 text-sm"
-                  />
-                </td>
-                <td className="p-2 font-mono text-xs">{c.id}</td>
-                <td className="p-2">{c.name}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <button type="submit" className="rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-700">
-          表示順を保存（小さい順に表示されます）
-        </button>
-      </form>
+      <CategoryOrderList categories={categories} />
 
       <form action={createBlogCategoryAction} className="space-y-3 rounded-lg border border-gray-200 bg-white p-4">
         <h2 className="font-bold">カテゴリ追加（末尾に追加されます）</h2>


### PR DESCRIPTION
## 概要
#1133 の改修項目「カテゴリー表示順の操作を容易にしたい（D&Dが理想）」の対応。

- 数値入力による表示順編集を廃止し、**ドラッグ&ドロップで並べ替えられるリスト**（`category-order-list.tsx`）に置き換え
  - HTML5 Drag and Drop API（ライブラリ追加なし）。ドラッグ中は行がハイライトされ、重なった位置にリアルタイムで移動
  - マウス操作が難しい場合のフォールバックとして各行に ↑↓ ボタンも用意
- 「この並び順で保存」ボタンで確定。並び順は hidden input（`order_{id}` = index）として送信され、**既存の一括更新アクションをそのまま使用**（sort_orderは0始まりの連番に正規化される）
- カテゴリ追加フォームは従来どおり

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)