### PR TITLE
feat(admin): 本文形式（Markdown/HTML）を編集画面で変更可能に

### DIFF
--- a/admin-pages/app/blog/actions.ts
+++ b/admin-pages/app/blog/actions.ts
@@ -20,6 +20,7 @@ import { purgeBlogContentCache, purgeBlogMetaCache } from '@/lib/cache'
 import { saveBlogContentDraft } from '@/lib/draft_blog'
 import { notifyBlogPublishToSNS } from '@/lib/sns'
 import { generateContentID } from '@/lib/id'
+import { parseContentFormat } from '@/lib/content-format'
 import type { PreviewActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
@@ -47,6 +48,7 @@ function parseBlogForm(formData: FormData): { input: BlogContentInput; error?: s
     id,
     title: text(formData, 'title'),
     content: (formData.get('content') as string | null) ?? '',
+    content_format: parseContentFormat(formData.get('content_format') as string | null),
     ogp_image: textOrNull(formData, 'ogp_image'),
     sns_text: textOrNull(formData, 'sns_text'),
     is_secret: formData.get('is_secret') === 'on',
@@ -163,6 +165,7 @@ function parseInfoForm(formData: FormData): { input: BlogInfoInput; error?: stri
     page_pathname: text(formData, 'page_pathname'),
     title: textOrNull(formData, 'title'),
     main_text: (formData.get('main_text') as string | null) ?? '',
+    main_text_format: parseContentFormat(formData.get('main_text_format') as string | null),
     status: parseStatus(formData),
   }
   if (!ID_PATTERN.test(input.id)) {

--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -54,10 +54,20 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
         </div>
 
         <div>
-          <label className="block text-sm font-medium">
-            本文（{article?.content_format === 'html' ? 'HTML（既存記事のため）' : 'Markdown'}。独自記法は cms_doc.md
-            参照）
-          </label>
+          <div className="flex items-center gap-3">
+            <label className="block text-sm font-medium">本文（独自記法は cms_doc.md 参照）</label>
+            <select
+              name="content_format"
+              defaultValue={article?.content_format ?? 'markdown'}
+              className="rounded-md border border-gray-300 p-1 text-xs"
+            >
+              <option value="markdown">Markdown</option>
+              <option value="html">HTML（旧CMS形式）</option>
+            </select>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            形式を変更しても本文は自動変換されません。切り替える場合は本文の書き直しとセットで保存してください
+          </p>
           <textarea
             name="content"
             defaultValue={article?.content ?? ''}

--- a/admin-pages/app/blog/info/info-form.tsx
+++ b/admin-pages/app/blog/info/info-form.tsx
@@ -45,9 +45,20 @@ export function InfoForm({ mode, info, error }: Props) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium">
-            本文（{info?.main_text_format === 'html' ? 'HTML（既存ページのため）' : 'Markdown'}）
-          </label>
+          <div className="flex items-center gap-3">
+            <label className="block text-sm font-medium">本文</label>
+            <select
+              name="main_text_format"
+              defaultValue={info?.main_text_format ?? 'markdown'}
+              className="rounded-md border border-gray-300 p-1 text-xs"
+            >
+              <option value="markdown">Markdown</option>
+              <option value="html">HTML（旧CMS形式）</option>
+            </select>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
+          </p>
           <textarea
             name="main_text"
             defaultValue={info?.main_text ?? ''}

--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -14,6 +14,7 @@ import {
 import { purgeBandeDessineeCache } from '@/lib/cache'
 import { saveBandeDessineeDraft } from '@/lib/draft_comic'
 import { generateContentID } from '@/lib/id'
+import { parseContentFormat } from '@/lib/content-format'
 import type { PreviewActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
@@ -60,6 +61,7 @@ function parseComicForm(formData: FormData): { input: BandeDessineeInput; error?
     last_page: parseInt(text(formData, 'last_page'), 10),
     first_left_right: [firstLeftRight],
     description: (formData.get('description') as string | null) ?? '',
+    description_format: parseContentFormat(formData.get('description_format') as string | null),
     status: VALID_STATUS.includes(status as (typeof VALID_STATUS)[number])
       ? (status as BandeDessineeInput['status'])
       : 'DRAFT',

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -184,9 +184,20 @@ export function ComicForm({ mode, comic, allTags, allSeries, error }: Props) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium">
-            説明文（{comic?.description_format === 'html' ? 'HTML（既存記事のため）' : 'Markdown'}）
-          </label>
+          <div className="flex items-center gap-3">
+            <label className="block text-sm font-medium">説明文</label>
+            <select
+              name="description_format"
+              defaultValue={comic?.description_format ?? 'markdown'}
+              className="rounded-md border border-gray-300 p-1 text-xs"
+            >
+              <option value="markdown">Markdown</option>
+              <option value="html">HTML（旧CMS形式）</option>
+            </select>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
+          </p>
           <textarea
             name="description"
             defaultValue={comic?.description ?? ''}

--- a/admin-pages/app/illust/actions.ts
+++ b/admin-pages/app/illust/actions.ts
@@ -7,6 +7,7 @@ import { createAtelier, updateAtelier, getAtelier, createTag, type AtelierInput 
 import { purgeAtelierCache } from '@/lib/cache'
 import { saveAtelierDraft } from '@/lib/draft'
 import { generateContentID } from '@/lib/id'
+import { parseContentFormat } from '@/lib/content-format'
 import type { PreviewActionState } from '@/lib/form-state'
 
 const VALID_STATUS = ['PUBLISH', 'DRAFT', 'CLOSED'] as const
@@ -27,6 +28,7 @@ function parseAtelierForm(formData: FormData): { input: AtelierInput; error?: st
     src,
     object_position: VALID_POSITION.includes(objectPosition) ? objectPosition : 'center',
     description,
+    description_format: parseContentFormat(formData.get('description_format') as string | null),
     status: VALID_STATUS.includes(status as (typeof VALID_STATUS)[number])
       ? (status as AtelierInput['status'])
       : 'DRAFT',

--- a/admin-pages/app/illust/atelier-form.tsx
+++ b/admin-pages/app/illust/atelier-form.tsx
@@ -94,9 +94,20 @@ export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error
         </div>
 
         <div>
-          <label className="block text-sm font-medium">
-            説明文（{atelier?.description_format === 'html' ? 'HTML（既存記事のため）' : 'Markdown'}）
-          </label>
+          <div className="flex items-center gap-3">
+            <label className="block text-sm font-medium">説明文</label>
+            <select
+              name="description_format"
+              defaultValue={atelier?.description_format ?? 'markdown'}
+              className="rounded-md border border-gray-300 p-1 text-xs"
+            >
+              <option value="markdown">Markdown</option>
+              <option value="html">HTML（旧CMS形式）</option>
+            </select>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
+          </p>
           <textarea
             name="description"
             defaultValue={atelier?.description ?? ''}

--- a/admin-pages/lib/content-format.ts
+++ b/admin-pages/lib/content-format.ts
@@ -1,0 +1,7 @@
+// 本文の保存形式。html は旧CMS（microCMS）から移行した既存コンテンツ用、
+// markdown が新規コンテンツの標準（配信時に cms-data-fetcher が変換する）
+export type ContentFormat = 'markdown' | 'html'
+
+export function parseContentFormat(value: string | null, fallback: ContentFormat = 'markdown'): ContentFormat {
+  return value === 'html' || value === 'markdown' ? value : fallback
+}

--- a/admin-pages/lib/db.ts
+++ b/admin-pages/lib/db.ts
@@ -4,6 +4,7 @@
  */
 import { getCloudflareContext } from '@opennextjs/cloudflare'
 import type { atelierRow, atelierTagRow } from 'api-types'
+import type { ContentFormat } from './content-format'
 
 async function getDB(): Promise<D1Database> {
   const { env } = await getCloudflareContext({ async: true })
@@ -45,6 +46,7 @@ export type AtelierInput = {
   src: string
   object_position: string
   description: string
+  description_format: ContentFormat
   status: 'PUBLISH' | 'DRAFT' | 'CLOSED'
   tagIDs: string[]
 }
@@ -59,9 +61,19 @@ export async function createAtelier(input: AtelierInput): Promise<void> {
     .prepare(
       `INSERT INTO ateliers
         (id, title, src, object_position, description, description_format, status, created_at, updated_at, published_at, revised_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, 'markdown', ?6, ?7, ?7, ?8, ?8)`
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8, ?9, ?9)`
     )
-    .bind(input.id, input.title, input.src, input.object_position, input.description, input.status, now, publishedAt)
+    .bind(
+      input.id,
+      input.title,
+      input.src,
+      input.object_position,
+      input.description,
+      input.description_format,
+      input.status,
+      now,
+      publishedAt
+    )
     .run()
 
   await replaceTagRelations(db, input.id, input.tagIDs)
@@ -82,8 +94,8 @@ export async function updateAtelier(input: AtelierInput): Promise<void> {
   await db
     .prepare(
       `UPDATE ateliers SET
-        title = ?2, src = ?3, object_position = ?4, description = ?5, status = ?6,
-        updated_at = ?7, published_at = ?8, revised_at = ?9
+        title = ?2, src = ?3, object_position = ?4, description = ?5, description_format = ?6, status = ?7,
+        updated_at = ?8, published_at = ?9, revised_at = ?10
        WHERE id = ?1`
     )
     .bind(
@@ -92,6 +104,7 @@ export async function updateAtelier(input: AtelierInput): Promise<void> {
       input.src,
       input.object_position,
       input.description,
+      input.description_format,
       input.status,
       now,
       publishedAt,

--- a/admin-pages/lib/db_blog.ts
+++ b/admin-pages/lib/db_blog.ts
@@ -4,6 +4,7 @@
  */
 import { getCloudflareContext } from '@opennextjs/cloudflare'
 import type { blogContentRow, blogCategoryRow, blogInfoRow } from 'api-types'
+import type { ContentFormat } from './content-format'
 
 async function getDB(): Promise<D1Database> {
   const { env } = await getCloudflareContext({ async: true })
@@ -38,6 +39,7 @@ export type BlogContentInput = {
   id: string
   title: string
   content: string
+  content_format: ContentFormat
   ogp_image: string | null
   sns_text: string | null
   is_secret: boolean
@@ -55,7 +57,7 @@ export async function createBlogContent(input: BlogContentInput): Promise<void> 
     .prepare(
       `INSERT INTO blog_contents
         (id, title, content, content_format, ogp_image, sns_text, is_secret, secret_code, status, created_at, updated_at, published_at, revised_at)
-       VALUES (?1, ?2, ?3, 'markdown', ?4, ?5, ?6, ?7, ?8, ?9, ?9, ?10, ?10)`
+       VALUES (?1, ?2, ?3, ?11, ?4, ?5, ?6, ?7, ?8, ?9, ?9, ?10, ?10)`
     )
     .bind(
       input.id,
@@ -67,7 +69,8 @@ export async function createBlogContent(input: BlogContentInput): Promise<void> 
       input.secret_code,
       input.status,
       now,
-      publishedAt
+      publishedAt,
+      input.content_format
     )
     .run()
 
@@ -87,7 +90,7 @@ export async function updateBlogContent(input: BlogContentInput): Promise<void> 
   await db
     .prepare(
       `UPDATE blog_contents SET
-        title = ?2, content = ?3, ogp_image = ?4, sns_text = ?5, is_secret = ?6, secret_code = ?7, status = ?8,
+        title = ?2, content = ?3, content_format = ?12, ogp_image = ?4, sns_text = ?5, is_secret = ?6, secret_code = ?7, status = ?8,
         updated_at = ?9, published_at = ?10, revised_at = ?11
        WHERE id = ?1`
     )
@@ -102,7 +105,8 @@ export async function updateBlogContent(input: BlogContentInput): Promise<void> 
       input.status,
       now,
       publishedAt,
-      revisedAt
+      revisedAt,
+      input.content_format
     )
     .run()
 
@@ -179,6 +183,7 @@ export type BlogInfoInput = {
   page_pathname: string
   title: string | null
   main_text: string
+  main_text_format: ContentFormat
   status: 'PUBLISH' | 'DRAFT' | 'CLOSED'
 }
 
@@ -189,9 +194,18 @@ export async function createBlogInfo(input: BlogInfoInput): Promise<void> {
   await db
     .prepare(
       `INSERT INTO blog_info (id, page_pathname, title, main_text, main_text_format, status, created_at, updated_at, published_at, revised_at)
-       VALUES (?1, ?2, ?3, ?4, 'markdown', ?5, ?6, ?6, ?7, ?7)`
+       VALUES (?1, ?2, ?3, ?4, ?8, ?5, ?6, ?6, ?7, ?7)`
     )
-    .bind(input.id, input.page_pathname, input.title, input.main_text, input.status, now, publishedAt)
+    .bind(
+      input.id,
+      input.page_pathname,
+      input.title,
+      input.main_text,
+      input.status,
+      now,
+      publishedAt,
+      input.main_text_format
+    )
     .run()
 }
 
@@ -206,11 +220,21 @@ export async function updateBlogInfo(input: BlogInfoInput): Promise<void> {
   const revisedAt = input.status === 'PUBLISH' ? now : current.revised_at
   await db
     .prepare(
-      `UPDATE blog_info SET page_pathname = ?2, title = ?3, main_text = ?4, status = ?5,
+      `UPDATE blog_info SET page_pathname = ?2, title = ?3, main_text = ?4, main_text_format = ?9, status = ?5,
         updated_at = ?6, published_at = ?7, revised_at = ?8
        WHERE id = ?1`
     )
-    .bind(input.id, input.page_pathname, input.title, input.main_text, input.status, now, publishedAt, revisedAt)
+    .bind(
+      input.id,
+      input.page_pathname,
+      input.title,
+      input.main_text,
+      input.status,
+      now,
+      publishedAt,
+      revisedAt,
+      input.main_text_format
+    )
     .run()
 }
 

--- a/admin-pages/lib/db_comic.ts
+++ b/admin-pages/lib/db_comic.ts
@@ -4,6 +4,7 @@
  */
 import { getCloudflareContext } from '@opennextjs/cloudflare'
 import type { bandeDessineeRow, bandeDessineeTagRow, bandeDessineeSeriesRow } from 'api-types'
+import type { ContentFormat } from './content-format'
 
 async function getDB(): Promise<D1Database> {
   const { env } = await getCloudflareContext({ async: true })
@@ -55,6 +56,7 @@ export type BandeDessineeInput = {
   last_page: number
   first_left_right: ('left' | 'right')[]
   description: string
+  description_format: ContentFormat
   status: 'PUBLISH' | 'DRAFT' | 'CLOSED'
 }
 
@@ -69,7 +71,7 @@ export async function createBandeDessinee(input: BandeDessineeInput): Promise<vo
         (id, title_name, publish_date, publish_event, contents_url, next_id, previous_id, tag_id, series_id,
          cover, back_cover, format, filename, first_page, last_page, first_left_right,
          description, description_format, status, created_at, updated_at, published_at, revised_at)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, 'markdown', ?18, ?19, ?19, ?20, ?20)`
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?21, ?18, ?19, ?19, ?20, ?20)`
     )
     .bind(
       input.id,
@@ -91,7 +93,8 @@ export async function createBandeDessinee(input: BandeDessineeInput): Promise<vo
       input.description,
       input.status,
       now,
-      publishedAt
+      publishedAt,
+      input.description_format
     )
     .run()
 }
@@ -112,7 +115,7 @@ export async function updateBandeDessinee(input: BandeDessineeInput): Promise<vo
       `UPDATE bande_dessinees SET
         title_name = ?2, publish_date = ?3, publish_event = ?4, contents_url = ?5, next_id = ?6, previous_id = ?7,
         tag_id = ?8, series_id = ?9, cover = ?10, back_cover = ?11, format = ?12, filename = ?13,
-        first_page = ?14, last_page = ?15, first_left_right = ?16, description = ?17, status = ?18,
+        first_page = ?14, last_page = ?15, first_left_right = ?16, description = ?17, description_format = ?22, status = ?18,
         updated_at = ?19, published_at = ?20, revised_at = ?21
        WHERE id = ?1`
     )
@@ -137,7 +140,8 @@ export async function updateBandeDessinee(input: BandeDessineeInput): Promise<vo
       input.status,
       now,
       publishedAt,
-      revisedAt
+      revisedAt,
+      input.description_format
     )
     .run()
 }

--- a/admin-pages/lib/draft.ts
+++ b/admin-pages/lib/draft.ts
@@ -23,8 +23,8 @@ export async function saveAtelierDraft(input: AtelierInput): Promise<string> {
     src: input.src,
     object_position: input.object_position,
     description: input.description,
-    // 既存レコードの形式を維持する。新規（D1未保存）は markdown
-    description_format: current?.description_format ?? 'markdown',
+    // フォームで選択された形式でプレビューする（形式変更もプレビューで確認できるようにする）
+    description_format: input.description_format,
     status: input.status,
     created_at: current?.created_at ?? now,
     updated_at: now,

--- a/admin-pages/lib/draft_blog.ts
+++ b/admin-pages/lib/draft_blog.ts
@@ -18,7 +18,8 @@ export async function saveBlogContentDraft(input: BlogContentInput): Promise<str
     id: input.id,
     title: input.title,
     content: input.content,
-    content_format: current?.content_format ?? 'markdown',
+    // フォームで選択された形式でプレビューする（形式変更もプレビューで確認できるようにする）
+    content_format: input.content_format,
     ogp_image: input.ogp_image,
     sns_text: input.sns_text,
     is_secret: input.is_secret ? 1 : 0,

--- a/admin-pages/lib/draft_comic.ts
+++ b/admin-pages/lib/draft_comic.ts
@@ -32,7 +32,8 @@ export async function saveBandeDessineeDraft(input: BandeDessineeInput): Promise
     last_page: input.last_page,
     first_left_right: JSON.stringify(input.first_left_right),
     description: input.description,
-    description_format: current?.description_format ?? 'markdown',
+    // フォームで選択された形式でプレビューする（形式変更もプレビューで確認できるようにする）
+    description_format: input.description_format,
     status: input.status,
     created_at: current?.created_at ?? now,
     updated_at: now,


### PR DESCRIPTION
## 概要
#1133 の改修項目「一度HTMLで保存したコンテンツを再編集したいが、状況によってはMarkdownで書き直したいケースがあるため形式の任意変更か変換機能がほしい」の対応。

**「形式の任意変更」の方を採用**しました。HTML→Markdownの自動変換は独自記法（inline-markupのspan、画像URL+サブテキスト、コマンド行など）の劣化リスクが高く、変換結果の検証コストが本文の書き直しと大差ないためです。

- ブログ記事・固定ページ・イラスト・マンガの編集フォームに形式セレクタ（Markdown / HTML（旧CMS形式））を追加し、保存時に `*_format` カラムへ反映
- **本文は自動変換しません**（注意書きを表示）。HTML記事をMarkdown化する場合は、形式を切り替えて本文を書き直し → プレビューで確認 → 保存、という流れ
- KVプレビューも選択中の形式で描画されるため、保存前に書き直し結果を確認できます
- 新規作成時のデフォルトは従来どおり markdown

refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)