### PR TITLE
feat(admin): マンガ・イラスト公開時のSNS自動投稿を配線

### DIFF
--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/db_comic'
 import { purgeBandeDessineeCache } from '@/lib/cache'
 import { saveBandeDessineeDraft } from '@/lib/draft_comic'
+import { notifyComicPublishToSNS } from '@/lib/sns'
 import { generateContentID } from '@/lib/id'
 import { parseContentFormat } from '@/lib/content-format'
 import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
@@ -93,6 +94,7 @@ export async function createBandeDessineeAction(formData: FormData): Promise<voi
 
   await createBandeDessinee(input)
   await purgeBandeDessineeCache()
+  await notifyComicPublishToSNS({ input, type: 'new' })
 
   revalidatePath('/comic')
   // 保存後は一覧へ戻らず、作成したマンガの編集画面へ遷移する（連続編集のため）
@@ -105,8 +107,13 @@ export async function updateBandeDessineeAction(formData: FormData): Promise<voi
     redirect(`/comic/${input.id}/edit?error=${encodeURIComponent(error)}`)
   }
 
+  // SNS通知の「下書き→公開」判定のため保存前のstatusを取得しておく
+  const current = await getBandeDessinee(input.id)
+  const oldStatus = current?.status
+
   await updateBandeDessinee(input)
   await purgeBandeDessineeCache()
+  await notifyComicPublishToSNS({ input, type: 'edit', oldStatus })
 
   revalidatePath('/comic')
   // 保存後は一覧へ戻らず、編集画面に留まる

--- a/admin-pages/app/illust/actions.ts
+++ b/admin-pages/app/illust/actions.ts
@@ -6,6 +6,7 @@ import { getCloudflareContext } from '@opennextjs/cloudflare'
 import { createAtelier, updateAtelier, getAtelier, createTag, type AtelierInput } from '@/lib/db'
 import { purgeAtelierCache } from '@/lib/cache'
 import { saveAtelierDraft } from '@/lib/draft'
+import { notifyAtelierPublishToSNS } from '@/lib/sns'
 import { generateContentID } from '@/lib/id'
 import { parseContentFormat } from '@/lib/content-format'
 import type { PreviewActionState, PurgeActionState } from '@/lib/form-state'
@@ -55,6 +56,7 @@ export async function createAtelierAction(formData: FormData): Promise<void> {
 
   await createAtelier(input)
   await purgeAtelierCache()
+  await notifyAtelierPublishToSNS({ input, type: 'new' })
 
   revalidatePath('/illust')
   // 保存後は一覧へ戻らず、作成したイラストの編集画面へ遷移する（連続編集のため）
@@ -67,8 +69,13 @@ export async function updateAtelierAction(formData: FormData): Promise<void> {
     redirect(`/illust/${input.id}/edit?error=${encodeURIComponent(error)}`)
   }
 
+  // SNS通知の「下書き→公開」判定のため保存前のstatusを取得しておく
+  const current = await getAtelier(input.id)
+  const oldStatus = current?.status
+
   await updateAtelier(input)
   await purgeAtelierCache()
+  await notifyAtelierPublishToSNS({ input, type: 'edit', oldStatus })
 
   revalidatePath('/illust')
   // 保存後は一覧へ戻らず、編集画面に留まる

--- a/admin-pages/lib/sns.ts
+++ b/admin-pages/lib/sns.ts
@@ -4,20 +4,35 @@
  * Service Binding は同一アカウント内でバインディングを宣言した Worker からしか呼べないため、
  * microCMS Webhook 時代の APIキー・HMAC署名による認証は不要（cms_design.md「4. SNS 通知」参照）
  *
- * - 送信条件: blog記事の「新規公開」または「下書き→公開」かつ is_secret でない
+ * - 送信条件: 「新規公開」または「下書き→公開」（blogのみ is_secret を除外）
  * - SNS_NOTIFY_ENABLED が 'true' の環境でのみ送信する（staging/ローカルからの誤投稿防止）
  */
 import { getCloudflareContext } from '@opennextjs/cloudflare'
+import type { SNSPublishValue } from 'api-types'
 import type { BlogContentInput } from './db_blog'
+import type { BandeDessineeInput } from './db_comic'
+import type { AtelierInput } from './db'
 
-type NotifyParams = {
-  input: BlogContentInput
+type ContentStatus = 'PUBLISH' | 'DRAFT' | 'CLOSED'
+
+type NotifyMeta = {
   type: 'new' | 'edit'
   // edit の場合のみ。保存前の status
-  oldStatus?: 'PUBLISH' | 'DRAFT' | 'CLOSED'
+  oldStatus?: ContentStatus
 }
 
-export async function notifyBlogPublishToSNS({ input, type, oldStatus }: NotifyParams): Promise<void> {
+// 送信条件: 「新規公開」または「下書き→公開」。すでに公開済みのコンテンツの編集では投稿しない
+function isPublishEvent(status: ContentStatus, { type, oldStatus }: NotifyMeta): boolean {
+  if (status !== 'PUBLISH') {
+    return false
+  }
+  if (type === 'edit' && oldStatus === 'PUBLISH') {
+    return false
+  }
+  return true
+}
+
+async function publishToSNS(serviceType: 'blog' | 'illust' | 'comic', value: SNSPublishValue): Promise<void> {
   const { env } = await getCloudflareContext({ async: true })
 
   if (env.SNS_NOTIFY_ENABLED !== 'true') {
@@ -25,26 +40,63 @@ export async function notifyBlogPublishToSNS({ input, type, oldStatus }: NotifyP
     return
   }
 
-  // 送信条件: 限定公開でない記事の「新規公開」または「下書き→公開」
-  if (input.is_secret || input.status !== 'PUBLISH') {
-    return
-  }
-  if (type === 'edit' && oldStatus === 'PUBLISH') {
-    // すでに公開済みの記事の編集では投稿しない
-    return
-  }
-
   try {
-    await env.SNS_PUBLISHER.publishArticle('blog', {
-      id: input.id,
-      title: input.title,
-      sns_text: input.sns_text,
-      ogp_image: input.ogp_image,
-      is_secret: input.is_secret,
-    })
-    console.log(`SNS notify sent (article: ${input.id})`)
+    await env.SNS_PUBLISHER.publishArticle(serviceType, value)
+    console.log(`SNS notify sent (${serviceType}: ${value.id})`)
   } catch (e) {
-    // SNS通知の失敗で記事保存を失敗させない
+    // SNS通知の失敗でコンテンツ保存を失敗させない
     console.error('SNS notify error:', e)
   }
+}
+
+export async function notifyBlogPublishToSNS({
+  input,
+  type,
+  oldStatus,
+}: NotifyMeta & { input: BlogContentInput }): Promise<void> {
+  // 限定公開記事（is_secret=true）はSNSへ自動投稿しない
+  if (input.is_secret || !isPublishEvent(input.status, { type, oldStatus })) {
+    return
+  }
+  await publishToSNS('blog', {
+    id: input.id,
+    title: input.title,
+    sns_text: input.sns_text,
+    ogp_image: input.ogp_image,
+    is_secret: input.is_secret,
+  })
+}
+
+export async function notifyAtelierPublishToSNS({
+  input,
+  type,
+  oldStatus,
+}: NotifyMeta & { input: AtelierInput }): Promise<void> {
+  if (!isPublishEvent(input.status, { type, oldStatus })) {
+    return
+  }
+  await publishToSNS('illust', {
+    id: input.id,
+    title: input.title,
+    src: input.src,
+  })
+}
+
+export async function notifyComicPublishToSNS({
+  input,
+  type,
+  oldStatus,
+}: NotifyMeta & { input: BandeDessineeInput }): Promise<void> {
+  if (!isPublishEvent(input.status, { type, oldStatus })) {
+    return
+  }
+  // OGP画像は投稿側（sns-article-publisher）で cover または1ページ目（filename + first_page + format）から組み立てる
+  await publishToSNS('comic', {
+    id: input.id,
+    title_name: input.title_name,
+    cover: input.cover,
+    filename: input.filename,
+    first_page: input.first_page,
+    format: input.format,
+  })
 }


### PR DESCRIPTION
## 概要

管理ページからマンガ・イラストを公開したときにSNS自動投稿が動くようにする。これまでSNS通知はブログのみ配線されており、マンガ・イラストは管理ページ（D1）移行後にSNS投稿が動かない状態だった（旧microCMS Webhook経路は発火しない）。受け側の sns-article-publisher は RPC `publishArticle` で `comic` / `illust` に対応済みのため、呼び出し側の配線のみ追加した。

## 変更内容

- `admin-pages/lib/sns.ts`
  - 送信条件判定（新規公開・下書き→公開のみ、公開済み編集は除外）と RPC 呼び出し（`SNS_NOTIFY_ENABLED` チェック、通知失敗で保存を巻き込まない）を共通化
  - `notifyComicPublishToSNS` / `notifyAtelierPublishToSNS` を追加（`notifyBlogPublishToSNS` は挙動変更なし）
- `admin-pages/app/comic/actions.ts` / `admin-pages/app/illust/actions.ts`
  - 新規作成時に `type: 'new'` で通知
  - 更新時は保存前のstatusを取得し `type: 'edit', oldStatus` で通知（ブログと同じパターン）

## 確認

- [x] `tsc --noEmit` パス
- [ ] 実投稿はローカル・stagingでは `SNS_NOTIFY_ENABLED=false` のため確認不可。本番での初回公開時にWorkerログ（`RPC publishArticle: comic ...`）を確認する

## 関連

- 表紙未設定時のOGP画像フォールバックの既知の問題: #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)