### PR TITLE
feat(blog): ブログ記事に前後記事ナビゲーションを追加

### DIFF
--- a/cms-data-fetcher/src/d1_blog.ts
+++ b/cms-data-fetcher/src/d1_blog.ts
@@ -8,6 +8,7 @@
  */
 import {
   contentsAPIResult,
+  adjacentContentsResult,
   categoryAPIResult,
   infoAPIResult,
   staticAPIResult,
@@ -149,6 +150,48 @@ export async function getBlogContentFromD1(db: D1Database, articleID: string): P
   }
   const contents = await assembleContents(db, [row])
   return contents[0]
+}
+
+// 前後記事の取得。prev = 一つ前（古い方）、next = 一つあと（新しい方）
+// 一覧系と同様に限定公開記事はナビに出さない（基準記事自身は限定公開でも前後は計算する）
+// published_at が同時刻の記事でも順序が安定するよう id をタイブレークに使う
+export async function getBlogAdjacentContentsFromD1(
+  db: D1Database,
+  articleID: string
+): Promise<adjacentContentsResult> {
+  const base = await db
+    .prepare(
+      `SELECT id, COALESCE(published_at, created_at) AS published_at
+       FROM blog_contents WHERE id = ?1 AND status = 'PUBLISH'`
+    )
+    .bind(articleID)
+    .first<{ id: string; published_at: string }>()
+  // 未公開（下書きプレビュー等）は前後なしを返す
+  if (!base) {
+    return { prev: null, next: null }
+  }
+
+  const prev = await db
+    .prepare(
+      `SELECT id, title FROM blog_contents
+       WHERE status = 'PUBLISH' AND is_secret = 0
+         AND (COALESCE(published_at, created_at), id) < (?1, ?2)
+       ORDER BY COALESCE(published_at, created_at) DESC, id DESC LIMIT 1`
+    )
+    .bind(base.published_at, base.id)
+    .first<{ id: string; title: string }>()
+
+  const next = await db
+    .prepare(
+      `SELECT id, title FROM blog_contents
+       WHERE status = 'PUBLISH' AND is_secret = 0
+         AND (COALESCE(published_at, created_at), id) > (?1, ?2)
+       ORDER BY COALESCE(published_at, created_at) ASC, id ASC LIMIT 1`
+    )
+    .bind(base.published_at, base.id)
+    .first<{ id: string; title: string }>()
+
+  return { prev: prev ?? null, next: next ?? null }
 }
 
 // 限定公開記事のコード照合用メタ。secret_code を含むためクライアントへ渡さないこと

--- a/cms-data-fetcher/src/index.ts
+++ b/cms-data-fetcher/src/index.ts
@@ -6,6 +6,7 @@ import {
   bandeDessineeResult,
   categoryAPIResult,
   contentsAPIResult,
+  adjacentContentsResult,
   staticAPIResult,
   infoAPIResult,
   atelierResult,
@@ -36,6 +37,7 @@ import {
   getBlogContentsFromD1,
   getBlogContentsByTagFromD1,
   getBlogContentFromD1,
+  getBlogAdjacentContentsFromD1,
   getBlogSecretMetaFromD1,
   getBlogSecretMetaFromDraft,
   getBlogContentDraftFromKV,
@@ -81,7 +83,14 @@ export default class CMSDataFetcher extends WorkerEntrypoint<Env> {
     const contentID = searchParams.get('content_id')
     const draftKey = searchParams.get('draftKey') || undefined
 
-    if (pathname.includes('/cms/get_contents_with_tag')) {
+    if (pathname.includes('/cms/get_adjacent_contents')) {
+      // 前後記事（一つ前・一つあと）のナビ情報を取得
+      if (articleID === null) {
+        return new Response('articleID is empty', { status: 400 })
+      }
+      const adjacent = await this.fetchAdjacentContents(articleID)
+      return Response.json(adjacent)
+    } else if (pathname.includes('/cms/get_contents_with_tag')) {
       // タグで絞り込んで記事一覧を取得
       const contents = await this.fetchContentsByTag(tagIDsStr, offset, limit)
       return Response.json(contents)
@@ -198,6 +207,14 @@ export default class CMSDataFetcher extends WorkerEntrypoint<Env> {
     content.annotations = parsed.annotations
     // Cheerioオブジェクトに含まれる関数を削ぎ落とすためにJSON経由でシリアライズ
     return JSON.parse(JSON.stringify(content))
+  }
+
+  // 前後記事（一つ前・一つあと）の取得。D1移行後の新機能のためmicroCMS参照時は前後なしを返す
+  async fetchAdjacentContents(articleID: string): Promise<adjacentContentsResult> {
+    if (this.env.BLOG_SOURCE !== 'd1') {
+      return { prev: null, next: null }
+    }
+    return await getBlogAdjacentContentsFromD1(this.env.DB, articleID)
   }
 
   // 限定公開記事のコード照合用メタを取得する。secret_code を含むためクライアントには渡さない

--- a/cms-data-fetcher/test/d1_blog.spec.ts
+++ b/cms-data-fetcher/test/d1_blog.spec.ts
@@ -3,7 +3,13 @@
  */
 import { describe, it, expect } from 'vitest'
 import type { blogContentRow, blogCategoryRow, blogContentDraftRecord } from 'api-types'
-import { toContentsAPIResult, toCategoryAPIResult, getBlogContentDraftFromKV, getBlogSecretMetaFromDraft } from '../src/d1_blog'
+import {
+  toContentsAPIResult,
+  toCategoryAPIResult,
+  getBlogContentDraftFromKV,
+  getBlogSecretMetaFromDraft,
+  getBlogAdjacentContentsFromD1,
+} from '../src/d1_blog'
 import { parse } from '../src/parse'
 
 const categoryRow: blogCategoryRow = {
@@ -67,6 +73,64 @@ describe('toContentsAPIResult', () => {
     const result = toContentsAPIResult(secretRow, [])
     expect(result.is_secret).toBe(true)
     expect('secret_code' in result).toBe(false)
+  })
+})
+
+describe('getBlogAdjacentContentsFromD1', () => {
+  // 公開記事の並び（published_at昇順）: old_article < base < new_article
+  // secret_article は base と new_article の間だが is_secret=1 のためナビに出ない想定
+  const publishedRows = [
+    { id: 'old_article', title: '古い記事', published_at: '2026-07-01T00:00:00.000Z', is_secret: 0 },
+    { id: 'base_article', title: '基準記事', published_at: '2026-07-05T00:00:00.000Z', is_secret: 0 },
+    { id: 'secret_article', title: '限定公開記事', published_at: '2026-07-07T00:00:00.000Z', is_secret: 1 },
+    { id: 'new_article', title: '新しい記事', published_at: '2026-07-10T00:00:00.000Z', is_secret: 0 },
+  ]
+
+  // SQL文字列を見て挙動を切り替える簡易D1モック
+  const db = {
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => ({
+        first: async () => {
+          if (sql.includes('WHERE id = ?1')) {
+            const row = publishedRows.find((r) => r.id === params[0])
+            return row ? { id: row.id, published_at: row.published_at } : null
+          }
+          const [publishedAt, id] = params as [string, string]
+          const isPrev = sql.includes('< (?1, ?2)')
+          const candidates = publishedRows
+            .filter((r) => r.is_secret === 0)
+            .filter((r) =>
+              isPrev
+                ? r.published_at < publishedAt || (r.published_at === publishedAt && r.id < id)
+                : r.published_at > publishedAt || (r.published_at === publishedAt && r.id > id)
+            )
+            .sort((a, b) => (a.published_at < b.published_at ? -1 : 1))
+          const row = isPrev ? candidates[candidates.length - 1] : candidates[0]
+          return row ? { id: row.id, title: row.title } : null
+        },
+      }),
+    }),
+  } as unknown as D1Database
+
+  it('前後の公開記事を返す（限定公開記事はスキップされる）', async () => {
+    const result = await getBlogAdjacentContentsFromD1(db, 'base_article')
+    expect(result.prev).toEqual({ id: 'old_article', title: '古い記事' })
+    expect(result.next).toEqual({ id: 'new_article', title: '新しい記事' })
+  })
+
+  it('最古・最新の記事では片側がnullになる', async () => {
+    const oldest = await getBlogAdjacentContentsFromD1(db, 'old_article')
+    expect(oldest.prev).toBeNull()
+    expect(oldest.next).toEqual({ id: 'base_article', title: '基準記事' })
+
+    const newest = await getBlogAdjacentContentsFromD1(db, 'new_article')
+    expect(newest.prev).toEqual({ id: 'base_article', title: '基準記事' })
+    expect(newest.next).toBeNull()
+  })
+
+  it('基準記事が存在しない場合は両方null', async () => {
+    const result = await getBlogAdjacentContentsFromD1(db, 'no_such_article')
+    expect(result).toEqual({ prev: null, next: null })
   })
 })
 

--- a/packages/api-types/src/cms_types.ts
+++ b/packages/api-types/src/cms_types.ts
@@ -43,6 +43,18 @@ type contentsAPIResult = {
   is_secret?: boolean
 }
 
+// 記事下部の前後記事ナビ用。prev = 一つ前（古い方）、next = 一つあと（新しい方）
+// 限定公開記事は一覧系と同様にナビに含めない
+type adjacentArticle = {
+  id: string
+  title: string
+}
+
+type adjacentContentsResult = {
+  prev: adjacentArticle | null
+  next: adjacentArticle | null
+}
+
 type categoryAPIResult = {
   id: string
   createdAt: string
@@ -143,6 +155,7 @@ export type {
   TableOfContents,
   Annotation,
   contentsAPIResult,
+  adjacentContentsResult,
   categoryAPIResult,
   infoAPIResult,
   staticAPIResult,

--- a/packages/cms-cache-key-gen/src/generator.ts
+++ b/packages/cms-cache-key-gen/src/generator.ts
@@ -6,6 +6,10 @@ export function generateContentKey(articleID: string) {
   return `content_${articleID}`
 }
 
+export function generateAdjacentContentsKey(articleID: string) {
+  return `adjacent_contents_${articleID}`
+}
+
 export function generateSecretMetaKey(articleID: string) {
   return `secret_meta_${articleID}`
 }

--- a/pages/app/blog/[article_id]/article.tsx
+++ b/pages/app/blog/[article_id]/article.tsx
@@ -1,5 +1,5 @@
 import { FullArticle } from '@/components/large/article'
-import { getCMSContent, getSecretMeta } from '@/lib/api/workers'
+import { getAdjacentContents, getCMSContent, getSecretMeta } from '@/lib/api/workers'
 import { isArticleUnlocked } from '@/lib/secret_unlock'
 import { contentsAPIResult } from 'api-types'
 import SecretGate from './secret_gate'
@@ -38,6 +38,9 @@ export default async function BlogPageArticle({
     }
   }
 
+  // 前後記事ナビ。未公開記事のプレビュー時は前後なしが返るため描画されない
+  const adjacent = await getAdjacentContents(articleID)
+
   return (
     <div>
       <FullArticle
@@ -52,6 +55,7 @@ export default async function BlogPageArticle({
         type="blog"
         shareURL={url}
         annotations={content.annotations}
+        adjacent={adjacent}
       />
     </div>
   )

--- a/pages/components/large/article.tsx
+++ b/pages/components/large/article.tsx
@@ -6,8 +6,9 @@ import { Button } from '../ui/button'
 import ShareSection from '../middle/share_section'
 import { BookIcon, HomeIcon } from 'lucide-react'
 import ArticleContent from '../middle/article_content'
-import { Annotation, categoryAPIResult, ParsedContent, TableOfContents } from 'api-types'
+import { adjacentContentsResult, Annotation, categoryAPIResult, ParsedContent, TableOfContents } from 'api-types'
 import Annotations from '../middle/article_dom/annotations'
+import AdjacentArticleNav from '../middle/adjacent_article_nav'
 
 type ArticleProps = {
   id: string
@@ -24,6 +25,8 @@ type FullArticleProps = ArticleProps & {
   tableOfContents: TableOfContents
   draftKey?: string
   annotations?: Annotation[]
+  // 前後記事ナビ（blogのみ）。未指定なら表示しない
+  adjacent?: adjacentContentsResult
 }
 
 export async function Article({ id, title, updatedAt, parsedContents, categories }: ArticleProps) {
@@ -69,6 +72,7 @@ export async function FullArticle({
   draftKey,
   shareURL,
   annotations,
+  adjacent,
 }: FullArticleProps) {
   return (
     <Card lang="ja" className="w-full bg-gray-100">
@@ -101,10 +105,11 @@ export async function FullArticle({
         <Annotations annotations={annotations ?? []} />
       </CardContent>
       <CardFooter>
-        <div className="w-full">
-          <div className="flex gap-1 items-center justify-end">
+        <div className="w-full space-y-2">
+          <div className="flex gap-2 items-center justify-end">
             <ShareSection shareURL={shareURL} shareTitle={title} contentType="blog" />
           </div>
+          {adjacent && <AdjacentArticleNav adjacent={adjacent} />}
           <div className="flex justify-center mt-2">
             <Button variant="secondary" className="w-96 flex justify-center gap-1" asChild>
               <Link href="/">

--- a/pages/components/middle/adjacent_article_nav.tsx
+++ b/pages/components/middle/adjacent_article_nav.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { adjacentContentsResult } from 'api-types'
+import { Button } from '../ui/button'
+
+// 記事下部の前後記事ナビ。prev = 一つ前（古い方）、next = 一つあと（新しい方）
+export default function AdjacentArticleNav({ adjacent }: { adjacent: adjacentContentsResult }) {
+  const { prev, next } = adjacent
+  if (prev === null && next === null) {
+    return null
+  }
+  return (
+    <nav className="mb-4 flex justify-between gap-4" aria-label="前後の記事">
+      <div className="flex-1 min-w-0">
+        {prev && (
+          <Button variant="secondary" className="w-full h-auto justify-start gap-2 py-3" asChild>
+            <Link href={`/blog/${prev.id}`}>
+              <ChevronLeftIcon className="w-5 h-5 shrink-0" />
+              <span className="min-w-0 text-left">
+                <span className="block text-xs text-gray-500">Prev article</span>
+                <span className="block truncate">{prev.title}</span>
+              </span>
+            </Link>
+          </Button>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        {next && (
+          <Button variant="secondary" className="w-full h-auto justify-end gap-2 py-3" asChild>
+            <Link href={`/blog/${next.id}`}>
+              <span className="min-w-0 text-right">
+                <span className="block text-xs text-gray-500">Next article</span>
+                <span className="block truncate">{next.title}</span>
+              </span>
+              <ChevronRightIcon className="w-5 h-5 shrink-0" />
+            </Link>
+          </Button>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/pages/lib/api/workers.ts
+++ b/pages/lib/api/workers.ts
@@ -3,6 +3,7 @@ import {
   bandeDessineeResult,
   categoryAPIResult,
   contentsAPIResult,
+  adjacentContentsResult,
   staticAPIResult,
   infoAPIResult,
   OGPResult,
@@ -10,6 +11,7 @@ import {
 } from 'api-types'
 import { getLocalEnv, getNodeEnv, isKVCacheEnabled } from '../env'
 import {
+  generateAdjacentContentsKey,
   generateBandeDessineeContentKey,
   generateBandeDessineeKey,
   generateContentKey,
@@ -23,7 +25,7 @@ import {
   generateAtelierContentKey,
 } from 'cms-cache-key-gen'
 import { cache } from 'react'
-import { DAY } from '../static'
+import { DAY, HOUR } from '../static'
 
 // const revalidateTime = 0 // 無効にする。どうやらnext.jsのバグを踏んでいるっぽい
 const dev = getNodeEnv() === 'development'
@@ -32,6 +34,7 @@ const CacheTTL = {
   ogpData: 3 * DAY, // OGPデータの保持
   contents: 15 * DAY, // トップページなどのブログコンテンツリスト
   content: 10 * DAY, // 特定のブログコンテンツ
+  adjacentContents: 1 * HOUR, // 前後記事ナビ。新記事公開で「一つあとの記事」が変わるため記事本体と別キーで短め
   secretMeta: 0, // 限定公開記事のコード照合メタ。secret_codeを含むため常にskipCache（保持しない）
   contentsWithTags: 10 * DAY, // タグ指定のブログコンテンツリスト
   tags: 30 * DAY, // タグリスト
@@ -114,6 +117,7 @@ async function createLocalFetcher<TResult>(
 const getOGPData = cache(getOGPDataOrigin)
 const getCMSContents = cache(getCMSContentsOrigin)
 const getCMSContent = cache(getCMSContentOrigin)
+const getAdjacentContents = cache(getAdjacentContentsOrigin)
 const getSecretMeta = cache(getSecretMetaOrigin)
 const getCMSContentsWithTags = cache(getCMSContentsWithTagsOrigin)
 const getTags = cache(getTagsOrigin)
@@ -222,6 +226,23 @@ async function getCMSContentOrigin(articleID: string, draftKey?: string) {
     skipCache: !!draftKey, // draftKeyがある場合はキャッシュをスキップ
     // 限定公開記事は本文を KV に残さないようキャッシュ保存しない
     shouldCache: (res) => res?.is_secret !== true,
+  })
+}
+
+// 前後記事（一つ前・一つあと）ナビの取得
+async function getAdjacentContentsOrigin(articleID: string) {
+  const { env } = await getCloudflareContext({ async: true })
+  const isLocal = getLocalEnv() === 'local'
+  const defaultResult: adjacentContentsResult = { prev: null, next: null }
+
+  return createCachedAPIFunction<adjacentContentsResult>({
+    cacheKey: generateAdjacentContentsKey(articleID),
+    cacheTTL: CacheTTL.adjacentContents,
+    cacheStore: env.CMS_CACHE,
+    fetcher: isLocal
+      ? () => createLocalFetcher('/api/cms/get_adjacent_contents', { article_id: articleID }, defaultResult)
+      : () => env.CMS_RPC.fetchAdjacentContents(articleID),
+    defaultResult,
   })
 }
 
@@ -413,6 +434,7 @@ export {
   getOGPData,
   getCMSContents,
   getCMSContent,
+  getAdjacentContents,
   getSecretMeta,
   getCMSContentsWithTags,
   getTags,


### PR DESCRIPTION
## 概要

D1移行により実装可能になった「一つ前の記事」「一つあとの記事」のナビゲーションをブログ記事ページに追加します。

## 変更内容

### cms-data-fetcher
- `getBlogAdjacentContentsFromD1` を追加。基準記事の `published_at` を起点に `(published_at, id)` の行値比較で前後1件ずつ取得（同時刻の記事があっても順序が安定）
- 一覧系と同様に `is_secret = 0` で絞り、限定公開記事はナビに出さない（基準記事自身が限定公開でも前後は計算する）
- RPCメソッド `fetchAdjacentContents` と、ローカル開発用HTTPルート `/cms/get_adjacent_contents` を追加
- microCMS参照時（`BLOG_SOURCE !== 'd1'`）は前後なしを返す

### packages
- api-types: `adjacentContentsResult` 型（`{ prev, next }`、各要素は id/title のみ）
- cms-cache-key-gen: `generateAdjacentContentsKey`（`adjacent_contents_{articleID}`）

### pages
- `getAdjacentContents` を追加。記事本体キャッシュ（10日）とは**別キーでTTL 1時間**の短期キャッシュにし、新記事公開後は最長1時間で前の記事側に「Next article」リンクが反映される
- `AdjacentArticleNav` コンポーネントを新規作成し、`FullArticle` のカードフッター内（シェアボタンとHomeボタンの間）に表示
- blog記事のみ表示（infoページでは非表示）。未公開記事のドラフトプレビューでは前後なしが返るため表示されない

## テスト
- `cms-data-fetcher` のユニットテストに前後取得・限定公開スキップ・端の記事での片側null・基準記事不在のケースを追加（85件すべてパス）
- `cms-data-fetcher` / `pages` の型チェックパス（pagesの `app/blog/test` 参照エラーは `.next` の古い生成物による既存事象）
- ブラウザでの実表示確認は未実施（WSL環境のため）。stgデプロイ後に確認想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)