### PR TITLE
feat(cms): ローカル開発時にリモートD1を参照するようにする

### DIFF
--- a/cms-data-fetcher/wrangler.toml
+++ b/cms-data-fetcher/wrangler.toml
@@ -24,6 +24,8 @@ BLOG_SOURCE = "d1"
 binding = "DB"
 database_name = "maretol-cms"
 database_id = "58e13952-8750-4f5a-a75f-553bd4235f7c"
+# ローカル開発（wrangler dev）でもリモートの本番D1を参照する。デプロイ時の挙動には影響しない
+remote = true
 
 [dev]
 port = 8787


### PR DESCRIPTION
## 概要
ローカル開発（`wrangler dev` / `npm run dev:cms`）時に、cms-data-fetcher のD1バインディングをローカルのMiniflare（空のSQLite）ではなくリモートの本番D1（maretol-cms）へ接続するようにする。

## 変更内容
- cms-data-fetcher/wrangler.toml の `[[d1_databases]]` に `remote = true` を追加（Wrangler 4.x のリモートバインディング機能）

この設定は `wrangler dev` のときのみ有効で、デプロイ時の挙動には影響しない。リモート接続には `wrangler login` 済みの環境が必要。

## 動作確認
- `wrangler dev` 起動時にバインディング一覧で `env.DB (maretol-cms) D1 Database remote` を確認
- `localhost:8787/cms/get_contents` から本番D1の実記事データが返ることを確認

## 補足
- cms-data-fetcher は読み取り専用のWorkerのため、ローカル開発から本番DBへの書き込みは発生しない
- KVプレビュー（CMS_DRAFT）はローカルのまま。必要になったら同様に `remote = true` を追加できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)