### PR TITLE
feat(admin): 連携SNSへ同じ文面を同時投稿する機能を追加

### DIFF
--- a/admin-pages/app/layout.tsx
+++ b/admin-pages/app/layout.tsx
@@ -30,6 +30,9 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
               <Link href="/cache" className="text-gray-600 hover:text-gray-900">
                 キャッシュ
               </Link>
+              <Link href="/sns" className="text-gray-600 hover:text-gray-900">
+                SNS投稿
+              </Link>
             </nav>
           </div>
         </header>

--- a/admin-pages/app/sns/actions.ts
+++ b/admin-pages/app/sns/actions.ts
@@ -1,0 +1,13 @@
+'use server'
+
+import { postTextToSNS } from '@/lib/sns'
+import type { SNSPostActionState } from '@/lib/form-state'
+
+export async function postSNSTextAction(_prev: SNSPostActionState, formData: FormData): Promise<SNSPostActionState> {
+  const text = ((formData.get('text') as string | null) ?? '').trim()
+  if (text === '') {
+    return { error: '投稿する文面を入力してください' }
+  }
+
+  return await postTextToSNS(text)
+}

--- a/admin-pages/app/sns/page.tsx
+++ b/admin-pages/app/sns/page.tsx
@@ -1,0 +1,29 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare'
+import { SNSPostForm } from './sns-form'
+
+export const dynamic = 'force-dynamic'
+
+export default async function SNSPost() {
+  const { env } = await getCloudflareContext({ async: true })
+  const enabled = env.SNS_NOTIFY_ENABLED === 'true'
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">SNS投稿</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          連携済みのSNS（Twitter/X・Bluesky・Misskey・Nostr）へ同じ文面をそのまま投稿します。URLの組み立てやUTMパラメータの付与は行いません
+        </p>
+      </div>
+
+      {!enabled && (
+        <p className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+          この環境ではSNS投稿が無効化されています（SNS_NOTIFY_ENABLED が true
+          ではありません）。送信してもSNSには投稿されません
+        </p>
+      )}
+
+      <SNSPostForm />
+    </div>
+  )
+}

--- a/admin-pages/app/sns/sns-form.tsx
+++ b/admin-pages/app/sns/sns-form.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useActionState, useEffect, useState } from 'react'
+import { postSNSTextAction } from './actions'
+import { SubmitButton } from '@/components/submit-button'
+
+const TARGET_LABELS: Record<string, string> = {
+  twitter: 'Twitter/X',
+  bluesky: 'Bluesky',
+  misskey: 'Misskey',
+  nostr: 'Nostr',
+  mastodon: 'Mastodon',
+}
+
+export function SNSPostForm() {
+  const [state, formAction] = useActionState(postSNSTextAction, {})
+  const [text, setText] = useState('')
+
+  // すべてのSNSへ投稿できたら入力をクリアする
+  // 一部でも失敗したときは、文面を修正して再送できるよう保持する（成功済みSNSへの再送は二重投稿になる点に注意）
+  const allSucceeded = !!state.results?.length && state.results.every((r) => r.success)
+  useEffect(() => {
+    if (allSucceeded) {
+      setText('')
+    }
+  }, [allSucceeded, state])
+
+  return (
+    <form
+      action={formAction}
+      onSubmit={(e) => {
+        if (!confirm('連携SNSに投稿します。投稿は取り消せません。よろしいですか？')) {
+          e.preventDefault()
+        }
+      }}
+      className="max-w-2xl space-y-4"
+    >
+      <div>
+        <label htmlFor="sns-post-text" className="block text-sm font-medium">
+          文面
+        </label>
+        <textarea
+          id="sns-post-text"
+          name="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={8}
+          required
+          placeholder="投稿する文面"
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+        />
+        <p className="mt-1 text-xs text-gray-400">
+          {text.length} 文字。文字数上限は各SNSごとに異なります（Twitter/X は全角140文字相当）
+        </p>
+      </div>
+
+      {state.error && (
+        <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{state.error}</p>
+      )}
+
+      {state.results && (
+        <ul className="space-y-1 rounded-md border border-gray-200 bg-white p-3 text-sm">
+          {state.results.map((r) => (
+            <li key={r.target} className={r.success ? 'text-green-700' : 'text-red-700'}>
+              {TARGET_LABELS[r.target] ?? r.target}:{' '}
+              {r.success ? '投稿しました' : `失敗（${r.error ?? '不明なエラー'}）`}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <SubmitButton pendingText="投稿中...">SNSに投稿</SubmitButton>
+    </form>
+  )
+}

--- a/admin-pages/components/breadcrumbs.tsx
+++ b/admin-pages/components/breadcrumbs.tsx
@@ -8,6 +8,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   comic: 'マンガ',
   blog: 'ブログ',
   cache: 'キャッシュ管理',
+  sns: 'SNS投稿',
   new: '新規作成',
   edit: '編集',
   tags: 'タグ管理',

--- a/admin-pages/lib/form-state.ts
+++ b/admin-pages/lib/form-state.ts
@@ -1,3 +1,5 @@
+import type { SNSPostTextResult } from 'api-types'
+
 // useActionState で受け渡すプレビューアクションの結果
 // プレビューはページ遷移させない（遷移すると編集中の本文が消えるため）
 export type PreviewActionState = {
@@ -9,6 +11,13 @@ export type PreviewActionState = {
 // 編集画面上のボタンのためページ遷移させない（遷移すると編集中の本文が消えるため）
 export type PurgeActionState = {
   done?: string
+  error?: string
+}
+
+// useActionState で受け渡すSNS自由文面投稿の結果
+// 一部のSNSで失敗したときに文面を保持して再送できるよう、ページ遷移させない
+export type SNSPostActionState = {
+  results?: SNSPostTextResult[]
   error?: string
 }
 

--- a/admin-pages/lib/sns.ts
+++ b/admin-pages/lib/sns.ts
@@ -8,7 +8,7 @@
  * - SNS_NOTIFY_ENABLED が 'true' の環境でのみ送信する（staging/ローカルからの誤投稿防止）
  */
 import { getCloudflareContext } from '@opennextjs/cloudflare'
-import type { SNSPublishValue } from 'api-types'
+import type { SNSPostTextResult, SNSPublishValue } from 'api-types'
 import type { BlogContentInput } from './db_blog'
 import type { BandeDessineeInput } from './db_comic'
 import type { AtelierInput } from './db'
@@ -46,6 +46,24 @@ async function publishToSNS(serviceType: 'blog' | 'illust' | 'comic', value: SNS
   } catch (e) {
     // SNS通知の失敗でコンテンツ保存を失敗させない
     console.error('SNS notify error:', e)
+  }
+}
+
+// 管理ページからの自由文面投稿（sns-article-publisher の postText RPC 呼び出し）
+// 自動通知（publishToSNS）と異なり結果を画面に表示するため、エラーを握りつぶさず成否を返す
+export async function postTextToSNS(text: string): Promise<{ results?: SNSPostTextResult[]; error?: string }> {
+  const { env } = await getCloudflareContext({ async: true })
+
+  if (env.SNS_NOTIFY_ENABLED !== 'true') {
+    return { error: 'この環境ではSNS投稿が無効化されています（SNS_NOTIFY_ENABLED が true ではありません）' }
+  }
+
+  try {
+    const results = await env.SNS_PUBLISHER.postText(text)
+    return { results }
+  } catch (e) {
+    console.error('SNS post error:', e)
+    return { error: e instanceof Error ? e.message : 'SNSへの投稿に失敗しました' }
   }
 }
 

--- a/packages/api-types/src/sns_pub.ts
+++ b/packages/api-types/src/sns_pub.ts
@@ -3,3 +3,11 @@ export type SNSPubData = {
   article_title: string
   post_message: string | null
 }
+
+// 管理ページ（admin-pages）から sns-article-publisher の postText RPC で
+// 自由文面を投稿したときの、SNSごとの投稿結果
+export type SNSPostTextResult = {
+  target: 'twitter' | 'bluesky' | 'misskey' | 'nostr' | 'mastodon'
+  success: boolean
+  error?: string
+}

--- a/sns-article-publisher/src/bluesky.ts
+++ b/sns-article-publisher/src/bluesky.ts
@@ -15,7 +15,7 @@ type BlueSkyOGPInfo = {
 
 const defaultOGPSrc = 'https://r2.maretol.xyz/assets/maretol_base_ogp.png'
 
-async function PostBlueSky(env: Env, authInfo: BlueSkyAuthInfo, postText: string, ogp: BlueSkyOGPInfo): Promise<void> {
+async function PostBlueSky(env: Env, authInfo: BlueSkyAuthInfo, postText: string, ogp?: BlueSkyOGPInfo): Promise<void> {
   const agent = new AtpAgent({
     service: 'https://bsky.social',
   })
@@ -24,6 +24,15 @@ async function PostBlueSky(env: Env, authInfo: BlueSkyAuthInfo, postText: string
   await richText.detectFacets(agent)
 
   await agent.login({ identifier: authInfo.username, password: authInfo.password })
+
+  // OGP情報がない場合（記事に紐づかない自由文面の投稿）はリンクカードを付けずテキストのみ投稿する
+  if (!ogp) {
+    await agent.post({
+      text: richText.text,
+      facets: richText.facets,
+    })
+    return
+  }
 
   let blob = null
   try {

--- a/sns-article-publisher/src/index.ts
+++ b/sns-article-publisher/src/index.ts
@@ -1,7 +1,7 @@
 import PostTweet, { TwitterAuthInfo } from './twitter'
 import PostBlueSky, { BlueSkyAuthInfo } from './bluesky'
 import PostNostrKind1, { NostrAuthInfo } from './nostr'
-import { Content, ContentValue, SNSPublishValue, WebhookPayload } from 'api-types'
+import { Content, ContentValue, SNSPostTextResult, SNSPublishValue, WebhookPayload } from 'api-types'
 import { WorkerEntrypoint } from 'cloudflare:workers'
 import crypto from 'node:crypto'
 import NoteMisskey, { MisskeyAuthInfo } from './misskey'
@@ -54,6 +54,14 @@ export default class Publisher extends WorkerEntrypoint<Env> {
     const content = getContent(serviceType, value as ContentValue)
     console.log('RPC publishArticle:', serviceType, content.url)
     this.ctx.waitUntil(publish(this.env, content, serviceType))
+  }
+
+  // 管理ページ（admin-pages）から自由文面を各SNSへそのまま投稿する RPC
+  // 記事に紐づかないためURL組み立て・UTMパラメータ付与は行わない
+  // 結果を管理ページの画面に表示するため、publishArticle と異なり完了まで待って成否を返す
+  async postText(text: string): Promise<SNSPostTextResult[]> {
+    console.log('RPC postText')
+    return await postFreeText(this.env, text)
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -215,6 +223,33 @@ async function publish(env: Env, content: PublishContent, service: ServiceType) 
   } else {
     console.log('skip nostr')
   }
+}
+
+// 自由文面を有効な各SNSへそのまま投稿し、SNSごとの成否を返す
+async function postFreeText(env: Env, text: string): Promise<SNSPostTextResult[]> {
+  const results: SNSPostTextResult[] = []
+
+  const post = async (target: SNSTarget, doPost: () => Promise<unknown>) => {
+    if (!TARGET[target]) {
+      console.log(`skip ${target}`)
+      return
+    }
+    console.log(`post to ${target}`)
+    try {
+      await doPost()
+      results.push({ target, success: true })
+    } catch (e) {
+      console.error(`Error posting to ${target}:`, e)
+      results.push({ target, success: false, error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  await post('twitter', () => PostTweet(createTwitterAuthInfo(env), text))
+  await post('bluesky', () => PostBlueSky(env, createBlueSkyAuthInfo(env), text))
+  await post('misskey', () => NoteMisskey(createMisskeyAuthInfo(env), text))
+  await post('nostr', () => PostNostrKind1(createNostrAuthInfo(env), text))
+
+  return results
 }
 
 function createTwitterAuthInfo(env: Env) {


### PR DESCRIPTION
## 概要

admin page に、連携済みSNS（Twitter/X・Bluesky・Misskey・Nostr）へ同じ文面をそのまま同時投稿する「SNS投稿」ページを追加します。投稿処理は既存のSNS自動投稿（sns-article-publisher）の各SNSクライアントと Service Binding を流用しています。

## 変更内容

### sns-article-publisher
- `Publisher` クラスに RPC `postText(text)` を追加。記事自動投稿（`publishArticle`）と異なり、結果を管理画面に表示するため完了まで待ってSNSごとの成否 `SNSPostTextResult[]` を返す
- 投稿は既存の `PostTweet` / `PostBlueSky` / `NoteMisskey` / `PostNostrKind1` と `TARGET` フラグを流用。記事に紐づかないため URL 組み立て・UTM パラメータ付与は行わない
- Bluesky クライアントの OGP 引数を省略可能にし、省略時はリンクカードなしのテキストのみ投稿に対応

### admin-pages
- `/sns` ページを追加（ナビ・パンくずにも追加）
  - 送信前に確認ダイアログを表示
  - SNSごとの成功/失敗を一覧表示。一部失敗時は文面を保持し再送可能（全件成功時はクリア）
  - `SNS_NOTIFY_ENABLED` が `true` でない環境（staging/ローカル）では警告バナーを表示し、既存の自動通知と同じゲートで投稿をスキップ
- `lib/sns.ts` に `postTextToSNS` を追加（自動通知と異なりエラーを握りつぶさず画面に返す）

### packages/api-types
- 投稿結果の共有型 `SNSPostTextResult` を追加

## 検証

- 両ワークスペースの `tsc --noEmit` 通過
- admin-pages の `next build` 成功（`/sns` ルート生成を確認）
- sns-article-publisher の `wrangler deploy --dry-run` でバンドル成功
- 実SNSへの投稿は本番認証情報が必要なため未実施

## デプロイ順の注意

sns-article-publisher → admin-pages の順でデプロイしてください（先に admin 側のみデプロイすると RPC `postText` が存在せずエラーになります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)