### PR TITLE
fix(pages): コミックビューワーのモード切替時のちらつきとページ位置ずれを修正

### DIFF
--- a/pages/components/middle/comicbook/index.tsx
+++ b/pages/components/middle/comicbook/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { use, useCallback, useMemo, useRef, useState } from 'react'
+import React, { use, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Swiper, SwiperClass, SwiperSlide } from 'swiper/react'
 import { Keyboard } from 'swiper/modules'
 import { Button } from '@/components/ui/button'
@@ -35,7 +35,11 @@ export default function ComicBook(props: ComicBookProps) {
   const startPage = data.first_page
   const lastPage = data.last_page
   const format = data.format[0]
-  const pageArray = Array.from({ length: lastPage - startPage + 1 }, (_, i) => i + startPage)
+  // メモ化しないと毎レンダーで再生成され、下流のuseMemo（originPageSrc/pageList）が毎回作り直されてしまう
+  const pageArray = useMemo(
+    () => Array.from({ length: lastPage - startPage + 1 }, (_, i) => i + startPage),
+    [startPage, lastPage],
+  )
 
   const coverPageSrc = data.cover ? baseUrl + '/' + data.cover : null
   const backCoverPageSrc = data.back_cover ? baseUrl + '/' + data.back_cover : null
@@ -75,6 +79,37 @@ export default function ComicBook(props: ComicBookProps) {
 
   const displayPageList = mode === 'double' ? pageList : singlePageList
   const totalPages = displayPageList.length
+
+  // 表示中ページの論理ID。モード切替でスライドリストが差し替わったときの位置復元に使う
+  // 差し替え直後はcurrentPageが旧リストのindexのままなので、復元（下のuseLayoutEffect）より後に更新されるよう通常のuseEffectで持つ
+  const currentPageIdRef = useRef<string | null>(null)
+  useEffect(() => {
+    currentPageIdRef.current = displayPageList[currentPage]?.id ?? currentPageIdRef.current
+  }, [currentPage, displayPageList])
+
+  // モード切替でリストが差し替わるとactiveIndexが別のページを指してしまうため、同じページIDの位置へ即時移動して復元する
+  // モードが実際に変わったときだけ動かす（それ以外のレンダーで動くと通常のページ送りと競合する）
+  const prevModeRef = useRef(mode)
+  useLayoutEffect(() => {
+    if (prevModeRef.current === mode) return
+    if (!swiperInstance || swiperInstance.destroyed) return
+    prevModeRef.current = mode
+    const pageId = currentPageIdRef.current
+    if (pageId === null) return
+
+    let index = displayPageList.findIndex((page) => page.id === pageId)
+    if (index < 0) {
+      // singleモードで除外される先頭・末尾の空白スライドにいた場合は最寄りの端ページへ
+      index = pageList.findIndex((page) => page.id === pageId) <= 0 ? 0 : displayPageList.length - 1
+    }
+    if (mode === 'double') {
+      // 見開きの先頭（偶数index）に揃える
+      index -= index % 2
+    }
+    if (index !== swiperInstance.activeIndex) {
+      swiperInstance.slideTo(index, 0)
+    }
+  }, [mode, swiperInstance, displayPageList, pageList])
 
   const handleNextPage = useCallback(() => {
     if (!swiperInstance) return
@@ -136,8 +171,8 @@ export default function ComicBook(props: ComicBookProps) {
           className="h-full w-full"
           lazyPreloadPrevNext={SWIPER.LAZY_PRELOAD}
         >
-          {displayPageList.map((page, i) => (
-            <SwiperSlide key={i}>
+          {displayPageList.map((page) => (
+            <SwiperSlide key={page.id}>
               <ComicSlide mode={mode} page={page} />
             </SwiperSlide>
           ))}

--- a/pages/components/middle/comicbook/navigation_icons.tsx
+++ b/pages/components/middle/comicbook/navigation_icons.tsx
@@ -29,11 +29,11 @@ function NavigationIcons(props: NavigationIconsProps) {
         tabIndex={0}
         aria-label="次のページへ"
         className={cn(
-          'text-white h-20 w-20 cursor-pointer',
+          'text-white h-20 w-20 cursor-pointer mix-blend-difference',
           // swiper-wrapperがz-index: 1を持つため、ページ画像より手前に出すにはそれより上げる必要がある
           'absolute z-10 left-0 top-1/2 flex justify-center items-center opacity-30',
           pageOption.controller_visible && 'opacity-100',
-          zoneFlag === 'next' && 'opacity-100'
+          zoneFlag === 'next' && 'opacity-100',
         )}
         onClick={onNextPage}
         onKeyDown={(e) => handleKeyDown(e, onNextPage)}
@@ -45,10 +45,10 @@ function NavigationIcons(props: NavigationIconsProps) {
         tabIndex={0}
         aria-label="前のページへ"
         className={cn(
-          'text-white h-20 w-20 cursor-pointer',
+          'text-white h-20 w-20 cursor-pointer mix-blend-difference',
           'absolute z-10 right-0 top-1/2 flex justify-center items-center opacity-30',
           pageOption.controller_visible && 'opacity-100',
-          zoneFlag === 'prev' && 'opacity-100'
+          zoneFlag === 'prev' && 'opacity-100',
         )}
         onClick={onPrevPage}
         onKeyDown={(e) => handleKeyDown(e, onPrevPage)}

--- a/pages/components/middle/comicbook/types.ts
+++ b/pages/components/middle/comicbook/types.ts
@@ -1,4 +1,5 @@
 export type PageState = {
+  id: string // モード間で共通の論理ページID。モード切替時の表示位置の復元とReactのkeyに使う
   position: 'left' | 'right' | 'center' // 見開き時の視覚上の配置。rightが先に読むページ、centerは表紙・裏表紙
   src: string | null // null = 見開き整列用の空白スライド
 }

--- a/pages/components/middle/comicbook/utils.ts
+++ b/pages/components/middle/comicbook/utils.ts
@@ -16,35 +16,51 @@ type CreatePageListParams = {
 // 1スライド=1ページのリストを生成する
 // 常に2スライドずつ追加するためリスト長は必ず偶数になり、偶数indexが見開きの先頭（視覚上の右ページ）になる
 // この整列を保つため、ページのない箇所には空白スライド（src: null）を挿入する
+// idはsingle/double両モードのリストで共通になるため、モード切替時のページ位置の復元に使える
 export function createPageList(params: CreatePageListParams): PageState[] {
   const { coverPageSrc, backCoverPageSrc, startPageLeftRight, originPageSrc } = params
   const pageList: PageState[] = []
 
   // 表紙が指定済みの場合（ない場合スキップ。空白と連続しないよう視覚上の左側に配置
   if (coverPageSrc) {
-    pageList.push({ position: 'right', src: null }, { position: 'center', src: coverPageSrc })
+    pageList.push(
+      { id: 'blank-cover', position: 'right', src: null },
+      { id: 'cover', position: 'left', src: coverPageSrc },
+    )
   }
 
   if (originPageSrc.length > 0) {
     let pairStart = 0
     if (startPageLeftRight === 'left') {
       // 本文1ページ目が左だった場合、最初の見開きは左側だけにページが入る
-      pageList.push({ position: 'right', src: null }, { position: 'left', src: originPageSrc[0] })
+      pageList.push(
+        { id: 'blank-head', position: 'right', src: null },
+        { id: 'page-0', position: 'left', src: originPageSrc[0] },
+      )
       pairStart = 1
     }
     for (let i = pairStart; i < originPageSrc.length; i += 2) {
       if (i >= originPageSrc.length - 1) {
         // 最後のページが1ページだけだった場合、右側だけにページが入る
-        pageList.push({ position: 'right', src: originPageSrc[i] }, { position: 'left', src: null })
+        pageList.push(
+          { id: `page-${i}`, position: 'right', src: originPageSrc[i] },
+          { id: 'blank-tail', position: 'left', src: null },
+        )
         break
       }
-      pageList.push({ position: 'right', src: originPageSrc[i] }, { position: 'left', src: originPageSrc[i + 1] })
+      pageList.push(
+        { id: `page-${i}`, position: 'right', src: originPageSrc[i] },
+        { id: `page-${i + 1}`, position: 'left', src: originPageSrc[i + 1] },
+      )
     }
   }
 
   // 裏表紙が指定済みの場合（ない場合スキップ。空白と連続しないよう視覚上の右側に配置
   if (backCoverPageSrc) {
-    pageList.push({ position: 'center', src: backCoverPageSrc }, { position: 'left', src: null })
+    pageList.push(
+      { id: 'back-cover', position: 'right', src: backCoverPageSrc },
+      { id: 'blank-back-cover', position: 'left', src: null },
+    )
   }
 
   return pageList


### PR DESCRIPTION
## 概要

#1154 の修正です。画面幅が980pxを跨いでsingle/doubleモードが切り替わる際、スライドリストが別リストに差し替わることでちらつき・表示位置の飛びが発生していた問題を、論理ページIDによる位置復元(案A: 最小修正)で解消します。

## 変更内容

- `PageState` にモード間で共通の論理ページID(`id`)を追加(`cover` / `page-N` / `blank-head` など)。single用リストはdouble用リストのサブセットのため、IDが両モードで共通になる
- `SwiperSlide` のkeyをindexから `page.id` に変更し、リスト差し替え時もDOMを再利用してちらつきを防止
- モード切替時に `useLayoutEffect` で同じIDのスライドへ `slideTo(index, 0)` して描画前に位置を復元
  - doubleモードでは見開き先頭(偶数index)に整列
  - singleモードで除外される先頭・末尾の空白スライドにいた場合は最寄りの端ページへフォールバック
- `pageArray` をメモ化(毎レンダーで `pageList` まで再生成されていた既存問題の修正。位置復元effectとの競合による無限ループ防止にも必要)
- 表紙・裏表紙の `position` を `left`/`right` に変更し、本文ページと同様にシーム側へ寄せる表示に
- ナビゲーションアイコンに `mix-blend-difference` を追加し、白い画像上でも視認できるように

## 既知の許容挙動

見開きの左側ページを表示中に single→double→single と往復すると、見開き先頭(右側ページ)に戻ります。マンガの見開き単位としては自然な挙動のため許容としています。

## 検証

- `tsc --noEmit` クリーン(既知の `.next` 生成物由来のエラーを除く)
- 8観点のコードレビュー(/code-review high)実施済み。CONFIRMEDの正確性指摘は上記の許容挙動のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)