### PR TITLE
feat(admin): マンガの前後の巻をセレクト化し双方向リンクを自動同期する

### DIFF
--- a/admin-pages/app/comic/[id]/edit/page.tsx
+++ b/admin-pages/app/comic/[id]/edit/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation'
-import { getBandeDessinee, listComicTags, listComicSeries } from '@/lib/db_comic'
+import { getBandeDessinee, listComicTags, listComicSeries, listBandeDessineeRefs } from '@/lib/db_comic'
 import { ComicForm } from '../../comic-form'
 import { purgeBandeDessineeCacheAction } from '../../actions'
 import { PurgeCacheButton } from '@/components/purge-cache-button'
@@ -11,16 +11,20 @@ export default async function EditComic({
   searchParams,
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ error?: string; saved?: string }>
+  searchParams: Promise<{ error?: string; saved?: string; info?: string }>
 }) {
   const { id } = await params
-  const { error, saved } = await searchParams
+  const { error, saved, info } = await searchParams
 
   const comic = await getBandeDessinee(id)
   if (!comic) {
     notFound()
   }
-  const [allTags, allSeries] = await Promise.all([listComicTags(), listComicSeries()])
+  const [allTags, allSeries, allComics] = await Promise.all([
+    listComicTags(),
+    listComicSeries(),
+    listBandeDessineeRefs(),
+  ])
 
   return (
     <div className="space-y-4">
@@ -36,8 +40,10 @@ export default async function EditComic({
         comic={comic}
         allTags={allTags}
         allSeries={allSeries}
+        allComics={allComics}
         error={error}
         saved={saved === '1'}
+        info={info}
       />
     </div>
   )

--- a/admin-pages/app/comic/actions.ts
+++ b/admin-pages/app/comic/actions.ts
@@ -7,10 +7,13 @@ import {
   createBandeDessinee,
   updateBandeDessinee,
   getBandeDessinee,
+  setBandeDessineeNextID,
+  setBandeDessineePreviousID,
   createComicTag,
   createComicSeries,
   type BandeDessineeInput,
 } from '@/lib/db_comic'
+import type { bandeDessineeRow } from 'api-types'
 import { purgeBandeDessineeCache } from '@/lib/cache'
 import { saveBandeDessineeDraft } from '@/lib/draft_comic'
 import { notifyComicPublishToSNS } from '@/lib/sns'
@@ -83,6 +86,88 @@ function parseComicForm(formData: FormData): { input: BandeDessineeInput; error?
   return { input }
 }
 
+type ChainNeighbors = { prev: bandeDessineeRow | null; next: bandeDessineeRow | null }
+
+// チェーン制約の検証（issue #1155）: 前後の巻は必ず同一シリーズ内で完結する
+// 検証で取得した隣接マンガの行は syncChainPointers で再利用する
+async function validateChain(input: BandeDessineeInput): Promise<{ neighbors: ChainNeighbors; error?: string }> {
+  const neighbors: ChainNeighbors = { prev: null, next: null }
+  if (!input.previous_id && !input.next_id) {
+    return { neighbors }
+  }
+
+  if (input.previous_id === input.id || input.next_id === input.id) {
+    return { neighbors, error: '前の巻・次の巻に自分自身は指定できません' }
+  }
+  if (input.previous_id && input.previous_id === input.next_id) {
+    return { neighbors, error: '前の巻と次の巻に同じマンガは指定できません' }
+  }
+  if (!input.series_id) {
+    return { neighbors, error: '前の巻・次の巻を設定するにはシリーズの設定が必要です' }
+  }
+  if (input.previous_id) {
+    neighbors.prev = await getBandeDessinee(input.previous_id)
+    if (!neighbors.prev) {
+      return { neighbors, error: `前の巻 '${input.previous_id}' が見つかりません` }
+    }
+    if (neighbors.prev.series_id !== input.series_id) {
+      return { neighbors, error: `前の巻「${neighbors.prev.title_name}」が同じシリーズではありません` }
+    }
+  }
+  if (input.next_id) {
+    neighbors.next = await getBandeDessinee(input.next_id)
+    if (!neighbors.next) {
+      return { neighbors, error: `次の巻 '${input.next_id}' が見つかりません` }
+    }
+    if (neighbors.next.series_id !== input.series_id) {
+      return { neighbors, error: `次の巻「${neighbors.next.title_name}」が同じシリーズではありません` }
+    }
+  }
+  return { neighbors }
+}
+
+// 双方向リンクの自動同期（issue #1155）。本体保存後に呼ぶ
+// - 新しい前後の巻の逆ポインタは無条件に上書きする（保存のたびに整合性が収束する）
+// - 付け替え・解除で残った旧リンクは、相手がまだ自分を指している場合のみ解除する
+// 実施内容はメッセージとして返し、保存後の画面で可視化する
+async function syncChainPointers(
+  input: BandeDessineeInput,
+  neighbors: ChainNeighbors,
+  current: bandeDessineeRow | null
+): Promise<string[]> {
+  const messages: string[] = []
+
+  const oldPrevId = current?.previous_id ?? null
+  if (oldPrevId && oldPrevId !== input.previous_id) {
+    const oldPrev = await getBandeDessinee(oldPrevId)
+    if (oldPrev?.next_id === input.id) {
+      await setBandeDessineeNextID(oldPrevId, null)
+      messages.push(`「${oldPrev.title_name}」の次の巻を解除しました`)
+    }
+  }
+  const oldNextId = current?.next_id ?? null
+  if (oldNextId && oldNextId !== input.next_id) {
+    const oldNext = await getBandeDessinee(oldNextId)
+    if (oldNext?.previous_id === input.id) {
+      await setBandeDessineePreviousID(oldNextId, null)
+      messages.push(`「${oldNext.title_name}」の前の巻を解除しました`)
+    }
+  }
+  if (neighbors.prev && neighbors.prev.next_id !== input.id) {
+    await setBandeDessineeNextID(neighbors.prev.id, input.id)
+    messages.push(`「${neighbors.prev.title_name}」の次の巻をこのマンガに設定しました`)
+  }
+  if (neighbors.next && neighbors.next.previous_id !== input.id) {
+    await setBandeDessineePreviousID(neighbors.next.id, input.id)
+    messages.push(`「${neighbors.next.title_name}」の前の巻をこのマンガに設定しました`)
+  }
+  return messages
+}
+
+function chainInfoParam(messages: string[]): string {
+  return messages.length > 0 ? `&info=${encodeURIComponent(messages.join(' / '))}` : ''
+}
+
 export async function createBandeDessineeAction(formData: FormData): Promise<void> {
   const { input, error } = parseComicForm(formData)
   if (error) {
@@ -91,14 +176,19 @@ export async function createBandeDessineeAction(formData: FormData): Promise<voi
   if (await getBandeDessinee(input.id)) {
     redirect(`/comic/new?error=${encodeURIComponent(`ID '${input.id}' は既に使用されています`)}`)
   }
+  const { neighbors, error: chainError } = await validateChain(input)
+  if (chainError) {
+    redirect(`/comic/new?error=${encodeURIComponent(chainError)}`)
+  }
 
   await createBandeDessinee(input)
+  const syncMessages = await syncChainPointers(input, neighbors, null)
   await purgeBandeDessineeCache()
   await notifyComicPublishToSNS({ input, type: 'new' })
 
   revalidatePath('/comic')
   // 保存後は一覧へ戻らず、作成したマンガの編集画面へ遷移する（連続編集のため）
-  redirect(`/comic/${input.id}/edit?saved=1`)
+  redirect(`/comic/${input.id}/edit?saved=1${chainInfoParam(syncMessages)}`)
 }
 
 export async function updateBandeDessineeAction(formData: FormData): Promise<void> {
@@ -107,17 +197,24 @@ export async function updateBandeDessineeAction(formData: FormData): Promise<voi
     redirect(`/comic/${input.id}/edit?error=${encodeURIComponent(error)}`)
   }
 
+  const { neighbors, error: chainError } = await validateChain(input)
+  if (chainError) {
+    redirect(`/comic/${input.id}/edit?error=${encodeURIComponent(chainError)}`)
+  }
+
   // SNS通知の「下書き→公開」判定のため保存前のstatusを取得しておく
+  // （前後リンクの付け替え掃除の判定にも旧値を使う）
   const current = await getBandeDessinee(input.id)
   const oldStatus = current?.status
 
   await updateBandeDessinee(input)
+  const syncMessages = await syncChainPointers(input, neighbors, current)
   await purgeBandeDessineeCache()
   await notifyComicPublishToSNS({ input, type: 'edit', oldStatus })
 
   revalidatePath('/comic')
   // 保存後は一覧へ戻らず、編集画面に留まる
-  redirect(`/comic/${input.id}/edit?saved=1`)
+  redirect(`/comic/${input.id}/edit?saved=1${chainInfoParam(syncMessages)}`)
 }
 
 // プレビューはページ遷移させず結果を useActionState で返す（遷移すると編集中の本文が消えるため）

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useActionState } from 'react'
+import { useActionState, useState } from 'react'
 import type { bandeDessineeRow, bandeDessineeTagRow, bandeDessineeSeriesRow } from 'api-types'
+import type { BandeDessineeRef } from '@/lib/db_comic'
 import { createBandeDessineeAction, updateBandeDessineeAction, previewBandeDessineeAction } from './actions'
 import { SubmitButton } from '@/components/submit-button'
 
@@ -10,8 +11,10 @@ type Props = {
   comic?: bandeDessineeRow
   allTags: bandeDessineeTagRow[]
   allSeries: bandeDessineeSeriesRow[]
+  allComics: BandeDessineeRef[]
   error?: string
   saved?: boolean
+  info?: string
 }
 
 // ISO 8601 UTC の日時を date input 用の JST 日付（YYYY-MM-DD）に変換する
@@ -21,16 +24,24 @@ function toJSTDateValue(iso: string | null | undefined): string {
   return jst.toISOString().slice(0, 10)
 }
 
-export function ComicForm({ mode, comic, allTags, allSeries, error, saved }: Props) {
+export function ComicForm({ mode, comic, allTags, allSeries, allComics, error, saved, info }: Props) {
   const action = mode === 'new' ? createBandeDessineeAction : updateBandeDessineeAction
   // プレビューはページ遷移させず結果だけ受け取る（遷移すると編集中の本文が消えるため）
   const [preview, previewFormAction] = useActionState(previewBandeDessineeAction, {})
   const inputClass = 'mt-1 w-full rounded-md border border-gray-300 p-2 text-sm'
   const monoClass = `${inputClass} font-mono`
 
+  // 前後の巻は同一シリーズ内でのみ設定できる（issue #1155）ため、
+  // シリーズと前後の巻のセレクトを連動させる（シリーズ変更時は前後の選択をクリア）
+  const [seriesId, setSeriesId] = useState(comic?.series_id ?? '')
+  const [previousId, setPreviousId] = useState(comic?.previous_id ?? '')
+  const [nextId, setNextId] = useState(comic?.next_id ?? '')
+  const seriesComics = seriesId === '' ? [] : allComics.filter((c) => c.series_id === seriesId && c.id !== comic?.id)
+
   return (
     <div className="space-y-4">
       {saved && <p className="rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-700">保存しました</p>}
+      {info && <p className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-700">自動連携: {info}</p>}
       {error && <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
       {preview.error && (
         <p className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{preview.error}</p>
@@ -105,7 +116,17 @@ export function ComicForm({ mode, comic, allTags, allSeries, error, saved }: Pro
           </div>
           <div>
             <label className="block text-sm font-medium">シリーズ</label>
-            <select name="series_id" defaultValue={comic?.series_id ?? ''} className={inputClass}>
+            <select
+              name="series_id"
+              value={seriesId}
+              onChange={(e) => {
+                setSeriesId(e.target.value)
+                // 前後の巻は同一シリーズ内でのみ有効なため、シリーズを変えたら選択をクリアする
+                setPreviousId('')
+                setNextId('')
+              }}
+              className={inputClass}
+            >
               <option value="">なし</option>
               {allSeries.map((s) => (
                 <option key={s.id} value={s.id}>
@@ -118,12 +139,50 @@ export function ComicForm({ mode, comic, allTags, allSeries, error, saved }: Pro
             </p>
           </div>
           <div>
-            <label className="block text-sm font-medium">前の巻ID（previous_id）</label>
-            <input name="previous_id" defaultValue={comic?.previous_id ?? ''} className={monoClass} />
+            <label className="block text-sm font-medium">前の巻（previous_id）</label>
+            <select
+              name="previous_id"
+              value={previousId}
+              onChange={(e) => setPreviousId(e.target.value)}
+              disabled={seriesId === ''}
+              className={inputClass}
+            >
+              <option value="">なし</option>
+              {seriesComics.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title_name}（{c.id}）
+                </option>
+              ))}
+              {previousId !== '' && !seriesComics.some((c) => c.id === previousId) && (
+                <option value={previousId}>{previousId}（シリーズ外・要修正）</option>
+              )}
+            </select>
+            <p className="mt-1 text-xs text-gray-400">
+              {seriesId === '' ? 'シリーズを選択すると設定できます' : '保存時に相手側の「次の巻」も自動設定されます'}
+            </p>
           </div>
           <div>
-            <label className="block text-sm font-medium">次の巻ID（next_id）</label>
-            <input name="next_id" defaultValue={comic?.next_id ?? ''} className={monoClass} />
+            <label className="block text-sm font-medium">次の巻（next_id）</label>
+            <select
+              name="next_id"
+              value={nextId}
+              onChange={(e) => setNextId(e.target.value)}
+              disabled={seriesId === ''}
+              className={inputClass}
+            >
+              <option value="">なし</option>
+              {seriesComics.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title_name}（{c.id}）
+                </option>
+              ))}
+              {nextId !== '' && !seriesComics.some((c) => c.id === nextId) && (
+                <option value={nextId}>{nextId}（シリーズ外・要修正）</option>
+              )}
+            </select>
+            <p className="mt-1 text-xs text-gray-400">
+              {seriesId === '' ? 'シリーズを選択すると設定できます' : '保存時に相手側の「前の巻」も自動設定されます'}
+            </p>
           </div>
           <div>
             <label className="block text-sm font-medium">表紙ファイル名（cover）</label>

--- a/admin-pages/app/comic/new/page.tsx
+++ b/admin-pages/app/comic/new/page.tsx
@@ -1,4 +1,4 @@
-import { listComicTags, listComicSeries } from '@/lib/db_comic'
+import { listComicTags, listComicSeries, listBandeDessineeRefs } from '@/lib/db_comic'
 import { ComicForm } from '../comic-form'
 
 export const dynamic = 'force-dynamic'
@@ -9,12 +9,16 @@ export default async function NewComic({
   searchParams: Promise<{ error?: string }>
 }) {
   const { error } = await searchParams
-  const [allTags, allSeries] = await Promise.all([listComicTags(), listComicSeries()])
+  const [allTags, allSeries, allComics] = await Promise.all([
+    listComicTags(),
+    listComicSeries(),
+    listBandeDessineeRefs(),
+  ])
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">マンガ新規作成</h1>
-      <ComicForm mode="new" allTags={allTags} allSeries={allSeries} error={error} />
+      <ComicForm mode="new" allTags={allTags} allSeries={allSeries} allComics={allComics} error={error} />
     </div>
   )
 }

--- a/admin-pages/lib/db_comic.ts
+++ b/admin-pages/lib/db_comic.ts
@@ -47,6 +47,42 @@ export async function listComicSeries(): Promise<bandeDessineeSeriesRow[]> {
   return result.results
 }
 
+// 前後の巻セレクトの候補用: シリーズで絞り込むため series_id を含む軽量な行
+export type BandeDessineeRef = {
+  id: string
+  title_name: string
+  series_id: string | null
+}
+
+export async function listBandeDessineeRefs(): Promise<BandeDessineeRef[]> {
+  const db = await getDB()
+  const result = await db
+    .prepare(
+      `SELECT id, title_name, series_id FROM bande_dessinees
+       ORDER BY publish_date IS NULL, publish_date, created_at`
+    )
+    .all<BandeDessineeRef>()
+  return result.results
+}
+
+// 双方向リンクの自動同期用: 隣接するマンガのポインタのみ書き換える
+// SNS通知・published_at 等の副作用を伴わないよう、通常の update とは分けている
+export async function setBandeDessineeNextID(id: string, nextId: string | null): Promise<void> {
+  const db = await getDB()
+  await db
+    .prepare(`UPDATE bande_dessinees SET next_id = ?2, updated_at = ?3 WHERE id = ?1`)
+    .bind(id, nextId, new Date().toISOString())
+    .run()
+}
+
+export async function setBandeDessineePreviousID(id: string, previousId: string | null): Promise<void> {
+  const db = await getDB()
+  await db
+    .prepare(`UPDATE bande_dessinees SET previous_id = ?2, updated_at = ?3 WHERE id = ?1`)
+    .bind(id, previousId, new Date().toISOString())
+    .run()
+}
+
 export type BandeDessineeInput = {
   id: string
   title_name: string


### PR DESCRIPTION
## 概要

closes #1155

CMS管理画面のマンガ編集で「前の巻・次の巻」を自由入力からセレクトに変更し、保存時に相手側マンガの逆ポインタを自動同期するようにします。設計の経緯・結論は issue のコメントを参照してください。

## 変更内容

### セレクト化（comic-form.tsx）
- 前の巻・次の巻の候補は**選択中のシリーズと同じシリーズのマンガのみ**（チェーンは同一シリーズ内で完結する、という今回導入した制約に基づく）
- シリーズ未選択時はセレクトをdisable、シリーズ変更時は前後の選択をクリア
- 既存データに制約違反のリンクがあった場合は「（シリーズ外・要修正）」として選択肢に残し、黙って消えないようにする

### 双方向自動同期（actions.ts）
- 前の巻にPを設定して保存すると、Pの次の巻が自動でこのマンガに設定される（次の巻も対称に動作）
- 相手側は**上書き型**で同期するため、幕間の挿入（前=P、次=Nを選んで保存）も1回の保存でチェーンが正しくつながる
- 付け替え・解除時は、旧隣接マンガの逆ポインタが**まだ自分を指している場合のみ**解除する
- 隣接マンガの更新は専用のポインタ更新関数（db_comic.ts）で行い、SNS通知やpublished_at更新の副作用を伴わない
- 自動連携の実施内容は保存後にメッセージで表示する

### サーバ側検証（actions.ts）
- 前後の巻の存在・同一シリーズであること・自己参照でないこと・前後が同一でないことを検証

## 動作確認

ローカルD1 + devサーバーでserver actionを直接実行して確認:

- [x] `tsc --noEmit` クリーン
- [x] 前の巻を設定 → 相手の `next_id` が自動設定され、メッセージ表示
- [x] 前の巻を解除 → 相手の `next_id` が自動クリア
- [x] シリーズ跨ぎの指定 → 検証エラーになりDBは無変更
- [x] 不整合データの「シリーズ外・要修正」フォールバック表示
- [x] 本番D1に制約違反の既存リンクがないことを確認（0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)