### PR TITLE
style(pages): 記事内テーブルのthead(ヘッダ行)にスタイルを追加

### DIFF
--- a/pages/app/globals.css
+++ b/pages/app/globals.css
@@ -187,6 +187,15 @@ code {
   }
   table {
     @apply w-auto;
+    thead {
+      @apply border-gray-600;
+      tr {
+        @apply border-b-2 border-gray-100;
+        th {
+          @apply py-2 pr-6 pl-4 border-x bg-gray-400 font-bold;
+        }
+      }
+    }
     tbody {
       tr {
         @apply border-b-2 border-gray-600;


### PR DESCRIPTION
## 概要
記事内Markdownから生成されるテーブルの`thead`(ヘッダ行)にスタイルが当たっていなかったため、`globals.css`にスタイルを追加しました。

## 変更内容
- `thead > tr`: 下線(`border-b-2 border-gray-100`)を追加
- `th`: パディング・縦罫線(`border-x`)・背景色(`bg-gray-400`)・太字を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)