### PR TITLE
fix(pages): blockquoteのcite記法解釈をtrimし引用元の二重表示を修正

### DIFF
--- a/pages/components/middle/article_dom/blockquote.tsx
+++ b/pages/components/middle/article_dom/blockquote.tsx
@@ -6,11 +6,12 @@ export default function Blockquote({
   text: string
   attrs?: { [name: string]: string }
 }) {
-  // text の cite:: 以降を引用元として解釈し、cite属性にセットする
+  // 引用元表記は引用の最終行に cite:: で記述する仕様。最後の cite:: 以降を引用元として解釈し、cite属性にセットする
+  // Markdown変換後のHTMLでは行末に改行が残るため、trimして解釈・除去する
   let citeText = ''
   let citeURL = null
   if (text.includes('cite::')) {
-    const lastLine = text.split('cite::').pop()
+    const lastLine = text.split('cite::').pop()?.trim()
     if (lastLine) {
       // lastLine は [引用元のテキスト](URL) という形式、または [引用元のテキスト] という形式
       const urlMatch = lastLine.match(/\(([^)]+)\)/)
@@ -26,7 +27,8 @@ export default function Blockquote({
           citeURL = lastLine
         }
       }
-      innerHTML = innerHTML.replace(`cite::${lastLine}`, '')
+      // 直前の <br> ごと除去し、引用末尾に空行が残らないようにする（<br> がない旧HTML構造では後者のみマッチ）
+      innerHTML = innerHTML.replace(`<br>\ncite::${lastLine}`, '').replace(`cite::${lastLine}`, '')
     }
   }
 


### PR DESCRIPTION
## 問題

Markdown形式の記事でblockquote内に `cite::` 記法を書くと、引用元が `<cite>` として表示されると同時に、本文中にも `cite::...` の行が生のまま残る二重表示になっていた。

## 原因

Markdown変換後のHTMLではblockquote内の行が `<br>` + 改行で1つの `<p>` に繋がるため、cheerioの `text()` から抽出した `cite::` 以降の文字列に末尾改行が残る。この改行付き文字列で `innerHTML.replace()` していたためマッチせず、本文からのcite行除去に失敗していた（innerHTML側は `cite::...` の直後が `</p>` で改行なし）。

microCMS時代のHTMLは行ごとに `<p>` が分かれタグ間に改行がなかったため顕在化していなかった。

## 修正

- 引用元表記は最終行に置く仕様（cms_doc.md）を前提に、最後の `cite::` 以降を **trimして** 解釈するように変更
- 本文からの除去は直前の `<br>` ごと取り除き、引用末尾に空行が残らないようにした（`<br>` がない旧HTML構造では従来どおりcite行のみ除去）

## 検証

新旧両HTML構造 × 記法3パターン（`[タイトル](URL)` / URLのみ / テキストのみ）で citeText / citeURL / 本文からの除去を確認。md-converter（32件）・cms-data-fetcher統合（10件）の既存テストもすべてパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)