### PR TITLE
feat(admin): 本文textareaでTabキーを\t入力として受け付ける

### DIFF
--- a/admin-pages/app/blog/blog-form.tsx
+++ b/admin-pages/app/blog/blog-form.tsx
@@ -9,6 +9,7 @@ import {
   addBlogCategoryInlineAction,
 } from './actions'
 import { SubmitButton } from '@/components/submit-button'
+import { ContentTextarea } from '@/components/content-textarea'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -81,7 +82,7 @@ export function BlogForm({ mode, article, selectedCategoryIDs = [], allCategorie
           <p className="mt-1 text-xs text-gray-400">
             形式を変更しても本文は自動変換されません。切り替える場合は本文の書き直しとセットで保存してください
           </p>
-          <textarea
+          <ContentTextarea
             name="content"
             defaultValue={article?.content ?? ''}
             rows={24}

--- a/admin-pages/app/blog/info/info-form.tsx
+++ b/admin-pages/app/blog/info/info-form.tsx
@@ -1,6 +1,7 @@
 import type { blogInfoRow } from 'api-types'
 import { createBlogInfoAction, updateBlogInfoAction } from '../actions'
 import { SubmitButton } from '@/components/submit-button'
+import { ContentTextarea } from '@/components/content-textarea'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -62,7 +63,7 @@ export function InfoForm({ mode, info, error, saved }: Props) {
           <p className="mt-1 text-xs text-gray-400">
             形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
           </p>
-          <textarea
+          <ContentTextarea
             name="main_text"
             defaultValue={info?.main_text ?? ''}
             rows={20}

--- a/admin-pages/app/blog/static/page.tsx
+++ b/admin-pages/app/blog/static/page.tsx
@@ -1,6 +1,7 @@
 import { listBlogStatic } from '@/lib/db_blog'
 import { updateBlogStaticAction } from '../actions'
 import { SubmitButton } from '@/components/submit-button'
+import { ContentTextarea } from '@/components/content-textarea'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,7 +28,7 @@ export default async function BlogStatic({ searchParams }: { searchParams: Promi
           >
             <input type="hidden" name="key" value={e.key} />
             <label className="block font-mono text-sm font-medium">{e.key}</label>
-            <textarea
+            <ContentTextarea
               name="value"
               defaultValue={e.value}
               rows={Math.min(6, Math.max(2, e.value.split('\n').length))}

--- a/admin-pages/app/comic/comic-form.tsx
+++ b/admin-pages/app/comic/comic-form.tsx
@@ -5,6 +5,7 @@ import type { bandeDessineeRow, bandeDessineeTagRow, bandeDessineeSeriesRow } fr
 import type { BandeDessineeRef } from '@/lib/db_comic'
 import { createBandeDessineeAction, updateBandeDessineeAction, previewBandeDessineeAction } from './actions'
 import { SubmitButton } from '@/components/submit-button'
+import { ContentTextarea } from '@/components/content-textarea'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -260,7 +261,7 @@ export function ComicForm({ mode, comic, allTags, allSeries, allComics, error, s
           <p className="mt-1 text-xs text-gray-400">
             形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
           </p>
-          <textarea
+          <ContentTextarea
             name="description"
             defaultValue={comic?.description ?? ''}
             rows={14}

--- a/admin-pages/app/illust/atelier-form.tsx
+++ b/admin-pages/app/illust/atelier-form.tsx
@@ -4,6 +4,7 @@ import { useActionState } from 'react'
 import type { atelierRow, atelierTagRow } from 'api-types'
 import { createAtelierAction, updateAtelierAction, previewAtelierAction } from './actions'
 import { SubmitButton } from '@/components/submit-button'
+import { ContentTextarea } from '@/components/content-textarea'
 
 type Props = {
   mode: 'new' | 'edit'
@@ -111,7 +112,7 @@ export function AtelierForm({ mode, atelier, selectedTagIDs = [], allTags, error
           <p className="mt-1 text-xs text-gray-400">
             形式を変更しても本文は自動変換されません。切り替える場合は書き直しとセットで保存してください
           </p>
-          <textarea
+          <ContentTextarea
             name="description"
             defaultValue={atelier?.description ?? ''}
             rows={12}

--- a/admin-pages/components/content-textarea.tsx
+++ b/admin-pages/components/content-textarea.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+// Tabキーでフォーカスを移動せず \t を挿入するtextarea。本文などタブ文字を含めたい入力に使う
+// Shift+Tabなど修飾キー付きは通常のフォーカス移動のままにする（キーボード操作での脱出手段を残す）
+export function ContentTextarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      onKeyDown={(e) => {
+        if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+          e.preventDefault()
+          // execCommandはUndo履歴に載るため優先し、非対応環境のみsetRangeTextで代替する
+          if (!document.execCommand('insertText', false, '\t')) {
+            const el = e.currentTarget
+            el.setRangeText('\t', el.selectionStart, el.selectionEnd, 'end')
+          }
+        }
+        props.onKeyDown?.(e)
+      }}
+    />
+  )
+}


### PR DESCRIPTION
Closes #1179

## 変更内容
- Tabキー押下時にフォーカス移動せず `\t` を挿入する共通コンポーネント `ContentTextarea` を追加
  - 挿入は `document.execCommand('insertText')` を優先（Undo履歴に載るため）、非対応環境では `setRangeText` にフォールバック
  - Shift+Tabや修飾キー付きTabは従来どおりフォーカス移動のまま（キーボード操作での脱出手段を残す）
- 以下の本文入力欄に適用
  - ブログ記事（blog-form）
  - お知らせ（info-form）
  - コミック説明文（comic-form）
  - イラスト説明文（atelier-form）
  - ブログ静的テキスト（blog/static）

## 対象外
- SNS投稿の文面欄はタブ入力の用途がないため従来どおり（必要なら適用します）

## 確認事項（手動）
- [ ] 本文textareaでTabを押すとタブ文字が挿入され、フォーカスが移動しない
- [ ] テキスト選択中にTabを押すと選択範囲がタブ文字で置き換わる
- [ ] Ctrl+Z / Cmd+ZでTab挿入がUndoできる
- [ ] Shift+Tabでは従来どおり前の要素にフォーカスが移動する

## 検証済み
- `tsc --noEmit` エラーなし（.next内の別ブランチ由来の古い成果物のエラーを除く）
- `next build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)